### PR TITLE
Add API documentation for backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,38 @@ For usage/contribution, please contact [@JermyTan](https://github.com/JermyTan)
 - Define constants instead of magic string
 - Use enums
 - Declare API response type
+
+## 🏗️ Architecture
+
+### Technology Stack
+
+- **Frontend**: React + TypeScript + Vite + Semantic UI React + Redux Toolkit
+- **Backend**: Django + Django REST Framework + PostgreSQL
+- **Infrastructure**: Docker + Nginx reverse proxy
+- **Authentication**: JWT tokens with Google/Facebook OAuth support
+
+### Project Structure
+
+```
+treeckle-3.0/
+├── frontend/          # React TypeScript application
+├── backend/           # Django REST API
+├── app-reverse-proxy/ # Nginx reverse proxy configuration
+├── core-reverse-proxy/# Core nginx configuration
+└── assets/            # Project assets and branding
+```
+
+## 🚀 Quick Start
+
+### Prerequisites
+
+- [Docker](https://docs.docker.com/desktop/) and Docker Compose
+- [Node.js](https://nodejs.org/) 16+ (for local frontend development)
+- [Python](https://python.org/) 3.9+ (for local backend development)
+
+### Development Setup
+
+See the detailed developer guides:
+
+- [Frontend Development Guide](./frontend/DEVELOPER_GUIDE.md)
+- [Backend Development Guide](./backend/DEVELOPER_GUIDE.md)

--- a/backend/DEVELOPER_GUIDE.md
+++ b/backend/DEVELOPER_GUIDE.md
@@ -1,0 +1,617 @@
+# Backend Developer Guide
+
+## 📋 Table of Contents
+
+- [Overview](#overview)
+- [Technology Stack](#technology-stack)
+- [Project Structure](#project-structure)
+- [Development Setup](#development-setup)
+- [Development Workflow](#development-workflow)
+- [API Documentation](#api-documentation)
+- [Database Management](#database-management)
+- [Code Style & Standards](#code-style--standards)
+- [Architecture & Design Patterns](#architecture--design-patterns)
+- [Troubleshooting](#troubleshooting)
+
+## 🎯 Overview
+
+The Treeckle backend is a Django REST API that provides comprehensive functionality for:
+
+- **User Authentication & Authorization**: JWT-based auth with role-based access control
+- **Facility Management**: Venue creation, categorization, and booking workflows
+- **Event Management**: Event creation, publishing, and RSVP handling
+- **Organization Multi-tenancy**: Support for multiple residential colleges
+- **Email Notifications**: Automated email system for bookings and events
+- **Content Delivery**: File upload and management with ImageKit integration
+
+## 🛠️ Technology Stack
+
+### Core Framework
+
+- **Django**: Web framework
+- **Django REST Framework**: REST API framework
+- **PostgreSQL**: Primary database (production)
+- **SQLite**: Development database (local)
+
+### Authentication & Security
+
+- **Django REST Framework SimpleJWT**: JWT token authentication
+- **Django CORS Headers**: Cross-origin resource sharing
+- **Django Argon2**: Password hashing
+
+### External Services
+
+- **ImageKit.io**: Image processing and CDN
+- **Django Anymail** with SendinBlue: Email service
+- **Gunicorn**: WSGI HTTP server for production
+
+### Development Tools
+
+- **Black**: Code formatting
+- **Ruff**: Fast Python linter
+- **DRF Spectacular**: OpenAPI schema generation
+- **Django Jazzmin**: Enhanced admin interface
+
+## 📁 Project Structure
+
+```
+backend/
+├── treeckle/                    # Main Django project
+│   ├── manage.py               # Django management script
+│   ├── treeckle/               # Project settings and configuration
+│   │   ├── settings.py         # Django settings
+│   │   ├── urls.py            # Main URL configuration
+│   │   ├── wsgi.py            # WSGI configuration
+│   │   └── fixtures/          # Seed data for development
+│   ├── authentication/        # JWT authentication app
+│   │   ├── models.py          # Auth models (Google, Facebook, OpenID, Password)
+│   │   ├── views.py           # Login endpoints
+│   │   ├── serializers.py     # Auth data serializers
+│   │   └── logic.py           # Authentication business logic
+│   ├── users/                 # User management app
+│   │   ├── models.py          # User, Organization, Role models
+│   │   ├── views.py           # User CRUD operations
+│   │   ├── permission_middlewares.py  # Role-based access control
+│   │   └── logic.py           # User business logic
+│   ├── organizations/         # Organization management
+│   │   ├── models.py          # Organization model
+│   │   └── admin.py           # Admin interface
+│   ├── venues/                # Venue and booking management
+│   │   ├── models.py          # Venue, VenueCategory, BookingNotificationSubscription
+│   │   ├── views.py           # Venue CRUD and notification endpoints
+│   │   ├── logic.py           # Venue business logic
+│   │   ├── middlewares.py     # Venue permission checks
+│   │   └── serializers.py     # Venue data serializers
+│   ├── bookings/              # Booking management
+│   │   ├── models.py          # Booking model with status workflow
+│   │   ├── views.py           # Booking CRUD and status management
+│   │   ├── logic.py           # Booking business logic
+│   │   ├── middlewares.py     # Booking permission checks
+│   │   └── serializers.py     # Booking data serializers
+│   ├── events/                # Event management
+│   │   ├── models.py          # Event, EventCategory, EventSignUp models
+│   │   ├── views/             # Event endpoints split by functionality
+│   │   │   ├── event.py       # Event CRUD operations
+│   │   │   └── sign_up.py     # Event sign-up management
+│   │   ├── logic/             # Event business logic
+│   │   ├── middlewares.py     # Event permission checks
+│   │   └── serializers.py     # Event data serializers
+│   ├── comments/              # Comment system
+│   ├── email_service/         # Email notification service
+│   ├── content_delivery_service/  # File upload and management
+│   ├── nusmods/              # NUSMods integration
+│   └── templates/            # Django templates
+├── requirements.txt          # Python dependencies
+├── Dockerfile               # Docker configuration
+├── docker-compose.yml       # Local development docker setup
+├── Makefile                 # Development commands
+├── .env.backend.local       # Local environment variables
+└── entrypoint.sh            # Docker entrypoint script
+```
+
+## 🚀 Development Setup
+
+### 1. Prerequisites
+
+Ensure you have the following installed:
+
+- [Python 3.9+](https://www.python.org/downloads/)
+- [Docker](https://docs.docker.com/desktop/) (for database and full-stack testing)
+- [Git](https://git-scm.com/)
+
+### 2. Clone and Navigate
+
+```bash
+git clone https://github.com/CAPTxTreeckle/Treeckle-3.0.git
+cd Treeckle-3.0/backend
+```
+
+### 3. Virtual Environment Setup
+
+**For macOS/Linux:**
+
+```bash
+python3 -m venv venv
+source venv/bin/activate
+```
+
+**For Windows:**
+
+```bash
+py -m venv venv
+
+# Command Prompt
+venv\Scripts\activate.bat
+
+# PowerShell
+venv\Scripts\Activate.ps1
+```
+
+### 4. Install Dependencies
+
+```bash
+pip install --upgrade pip
+pip install -r requirements.txt
+```
+
+### 5. Database Setup
+
+```bash
+# Apply migrations
+make migrate
+
+# Create superuser (optional)
+python treeckle/manage.py createsuperuser
+
+# Load seed data
+make seed
+```
+
+### 6. Run Development Server
+
+```bash
+make runserver
+# or
+python treeckle/manage.py runserver
+```
+
+The API will be available at `http://localhost:8000`
+
+## 🔄 Development Workflow
+
+### Using Docker (Recommended)
+
+For a complete development environment with PostgreSQL:
+
+```bash
+# Build and start all services
+make docker-up
+
+# View logs
+docker-compose logs -f backend
+
+# Stop services
+make docker-down
+
+# Restart services
+make docker-restart
+```
+
+### Code Quality
+
+Before committing any changes:
+
+```bash
+# Format code
+make format
+
+# Run linting
+make lint
+
+# Run tests (when available)
+python treeckle/manage.py test
+```
+
+### Database Operations
+
+```bash
+# Create new migrations after model changes
+make makemigrations
+
+# Apply migrations
+make migrate
+
+# Reset database (development only)
+python treeckle/manage.py flush
+make seed
+```
+
+## 📚 API Documentation
+
+### Accessing Documentation
+
+- **Swagger UI**: http://localhost:8000/api/swagger/ (Interactive API documentation)
+- **ReDoc**: http://localhost:8000/api/redoc/ (Alternative documentation format)
+- **OpenAPI Schema**: http://localhost:8000/api/schema/ (Raw JSON schema)
+
+## 🗄️ Database Management
+
+### Models Overview
+
+#### Core Models
+
+**User Model** (`users/models.py`)
+
+```python
+class User(AbstractUser):
+    name = CharField(max_length=255)
+    email = EmailField(unique=True)
+    organization = ForeignKey(Organization)
+    role = CharField(choices=Role.choices)
+    profile_image = ForeignKey(ProfileImage)
+```
+
+**Organization Model** (`organizations/models.py`)
+
+```python
+class Organization(TimestampedModel):
+    name = CharField(max_length=255, unique=True)
+```
+
+**Venue Model** (`venues/models.py`)
+
+```python
+class Venue(TimestampedModel):
+    organization = ForeignKey(Organization)
+    name = CharField(max_length=255)
+    category = ForeignKey(VenueCategory)
+    capacity = PositiveIntegerField()
+    ic_name = CharField(max_length=255)
+    ic_email = EmailField()
+    ic_contact_number = CharField(max_length=50)
+    form_field_data = JSONField()  # Custom booking form fields
+```
+
+**Booking Model** (`bookings/models.py`)
+
+```python
+class Booking(TimestampedModel):
+    title = CharField(max_length=255)
+    booker = ForeignKey(User)
+    venue = ForeignKey(Venue)
+    start_date_time = DateTimeField()
+    end_date_time = DateTimeField()
+    status = CharField(choices=BookingStatus.choices)
+    form_response_data = JSONField()  # User responses to custom form
+```
+
+### Migrations
+
+```bash
+# After making model changes
+python treeckle/manage.py makemigrations
+
+# Apply migrations
+python treeckle/manage.py migrate
+
+# Check migration status
+python treeckle/manage.py showmigrations
+
+# Rollback migration (if needed)
+python treeckle/manage.py migrate app_name migration_name
+```
+
+### Data Fixtures
+
+Load development data:
+
+```bash
+python treeckle/manage.py loaddata treeckle/treeckle/fixtures/seed_data.json
+```
+
+This creates:
+
+- **Admin account**: admin@capt.com / admin@capt.com
+- **Resident accounts**: resident1@capt.com through resident5@capt.com / resident1 through resident5
+- Sample venues and categories
+- Sample events and bookings
+
+## 🎨 Code Style & Standards
+
+### Code Formatting
+
+The project uses **Black** for code formatting:
+
+```bash
+# Format all Python files
+make format
+
+# Format specific file
+black path/to/file.py
+```
+
+### Linting
+
+The project uses **Ruff** for fast linting:
+
+```bash
+# Run linter
+make lint
+
+# Auto-fix issues where possible
+ruff check . --fix
+```
+
+### Coding Standards
+
+#### 1. **Naming Conventions**
+
+- Use `snake_case` for variables, functions, and file names
+- Use `PascalCase` for class names
+- Use `UPPER_CASE` for constants
+- Use descriptive names for variables and functions
+
+#### 2. **Import Organization**
+
+```python
+# Standard library imports
+import os
+from datetime import datetime
+
+# Third-party imports
+from django.db import models
+from rest_framework import status
+
+# Local imports
+from .models import Venue
+from users.models import User
+```
+
+#### 3. **String Formatting**
+
+- Use double quotes for strings
+- Use f-strings for string interpolation
+
+```python
+name = "John Doe"
+message = f"Hello, {name}!"
+```
+
+#### 4. **Documentation**
+
+- Add docstrings to all classes and functions
+- Use type hints where appropriate
+
+```python
+def create_booking(
+    user: User,
+    venue: Venue,
+    start_time: datetime
+) -> Booking:
+    """
+    Create a new booking for the given user and venue.
+
+    Args:
+        user: The user making the booking
+        venue: The venue being booked
+        start_time: The booking start time
+
+    Returns:
+        The created booking instance
+
+    Raises:
+        ValidationError: If booking conflicts with existing booking
+    """
+    # Implementation here
+```
+
+#### 5. **Error Handling**
+
+- Use specific exception types
+- Provide meaningful error messages
+
+```python
+from treeckle.common.exceptions import BadRequest, Conflict
+
+def update_booking_status(booking_id: int, status: str) -> Booking:
+    try:
+        booking = Booking.objects.get(id=booking_id)
+    except Booking.DoesNotExist:
+        raise NotFound(detail="Booking not found", code="booking_not_found")
+
+    if status not in BookingStatus.values:
+        raise BadRequest(detail="Invalid status", code="invalid_status")
+```
+
+## 🏗️ Architecture & Design Patterns
+
+### 1. **App Structure Pattern**
+
+Each Django app follows a consistent structure:
+
+```
+app_name/
+├── models.py          # Data models
+├── views.py           # API endpoints
+├── serializers.py     # Data serialization/validation
+├── logic.py           # Business logic (separate from views)
+├── middlewares.py     # Permission checks and decorators
+├── urls.py            # URL routing
+├── admin.py           # Django admin configuration
+└── migrations/        # Database migrations
+```
+
+### 2. **Separation of Concerns**
+
+- **Views**: Handle HTTP requests/responses, authentication, permission checking
+- **Logic**: Contain business logic, data processing, complex queries
+- **Serializers**: Handle data validation and serialization
+- **Models**: Define data structure and simple model methods
+- **Middlewares**: Handle cross-cutting concerns like permissions
+
+### 3. **Permission System**
+
+Role-based access control using decorators:
+
+```python
+from users.permission_middlewares import check_access
+from users.models import Role
+
+@check_access(Role.ADMIN)
+def admin_only_view(request, requester: User):
+    # Only accessible by admins
+    pass
+
+@check_access(Role.RESIDENT, Role.ORGANIZER, Role.ADMIN)
+def multi_role_view(request, requester: User):
+    # Accessible by multiple roles
+    pass
+```
+
+### 4. **Error Handling Pattern**
+
+Consistent error responses using custom exception classes:
+
+```python
+from treeckle.common.exceptions import BadRequest, NotFound, Conflict
+
+# In views.py
+def create_venue(request):
+    try:
+        venue = create_venue_logic(validated_data)
+    except IntegrityError:
+        raise Conflict(
+            detail="Venue already exists",
+            code="venue_exists"
+        )
+```
+
+### 5. **Data Transformation Pattern**
+
+Consistent JSON serialization using `*_to_json` functions:
+
+```python
+def venue_to_json(venue: Venue, full_details: bool = False) -> dict:
+    data = {
+        "id": venue.id,
+        "name": venue.name,
+        "category": venue.category.name,
+        # ... basic fields
+    }
+
+    if full_details:
+        data.update({
+            "form_field_data": venue.form_field_data,
+            "ic_name": venue.ic_name,
+            # ... additional fields
+        })
+
+    return data
+```
+
+### 6. **Query Optimization**
+
+Use `select_related` and `prefetch_related` for efficient queries:
+
+```python
+def get_bookings_with_related_data():
+    return Booking.objects.select_related(
+        'booker__organization',
+        'venue__category'
+    ).prefetch_related(
+        'venue__booking_notification_subscriptions'
+    )
+```
+
+## 🔧 Troubleshooting
+
+### Common Issues
+
+#### 1. **Database Connection Issues**
+
+```bash
+# Check database status
+python treeckle/manage.py dbshell
+
+# Reset database (development only)
+python treeckle/manage.py flush --noinput
+python treeckle/manage.py migrate
+python treeckle/manage.py loaddata treeckle/treeckle/fixtures/seed_data.json
+```
+
+#### 2. **Migration Conflicts**
+
+```bash
+# Check migration status
+python treeckle/manage.py showmigrations
+
+# Resolve conflicts by rolling back and reapplying
+python treeckle/manage.py migrate app_name 0001  # Roll back to specific migration
+python treeckle/manage.py migrate  # Reapply migrations
+```
+
+#### 3. **Permission Denied Errors**
+
+Check if the user has the correct role and organization:
+
+```python
+# In Django shell
+python treeckle/manage.py shell
+
+>>> from users.models import User
+>>> user = User.objects.get(email="user@example.com")
+>>> print(f"Role: {user.role}, Organization: {user.organization}")
+```
+
+#### 4. **Docker Issues**
+
+```bash
+# Clean up Docker containers and volumes
+make docker-down
+docker system prune -a
+docker volume prune
+
+# Rebuild from scratch
+make docker-up
+```
+
+#### 5. **Static Files Issues**
+
+```bash
+# Collect static files
+python treeckle/manage.py collectstatic --noinput
+
+# Check static files configuration in settings.py
+```
+
+### Debug Mode
+
+Enable debug logging in `settings.py`:
+
+```python
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+        },
+    },
+    'loggers': {
+        'django.db.backends': {
+            'handlers': ['console'],
+            'level': 'DEBUG',
+        },
+    },
+}
+```
+
+### Getting Help
+
+1. Check the [Django documentation](https://docs.djangoproject.com/)
+2. Check the [Django REST Framework documentation](https://www.django-rest-framework.org/)
+3. Review existing code patterns in the codebase
+
+---
+
+**Happy coding! 🎉**

--- a/backend/README.md
+++ b/backend/README.md
@@ -48,6 +48,14 @@ The backend should be running and accessible at `http://localhost:8000`
 > Username: dev  
 > Password: dev
 
+### API Documentation
+
+The API documentation is available at the following endpoints:
+
+- **Swagger UI**: http://localhost:8000/api/swagger/ - Interactive API documentation
+- **ReDoc**: http://localhost:8000/api/redoc/ - Alternative documentation format
+- **OpenAPI Schema**: http://localhost:8000/api/schema/ - Raw OpenAPI schema JSON
+
 ### Seeding the database
 
 To load seed data into the database, run the following command:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,3 +14,4 @@ django-json-widget
 black==25.1.0
 ruff==0.11.2
 pytz
+drf-spectacular

--- a/backend/treeckle/authentication/tests.py
+++ b/backend/treeckle/authentication/tests.py
@@ -1,2 +1,1 @@
-
 # Create your tests here.

--- a/backend/treeckle/authentication/views.py
+++ b/backend/treeckle/authentication/views.py
@@ -1,4 +1,6 @@
 from rest_framework_simplejwt.views import TokenViewBase
+from drf_spectacular.utils import extend_schema, extend_schema_view
+from drf_spectacular.openapi import OpenApiResponse
 from .serializers import (
     OpenIdLoginSerializer,
     GoogleLoginSerializer,
@@ -11,29 +13,243 @@ from .serializers import (
 
 
 # Create your views here.
+@extend_schema(
+    summary="Google OAuth Login",
+    description="Authenticate user using Google ID token and return JWT access/refresh tokens with user data",
+    tags=["Authentication"],
+    responses={
+        200: OpenApiResponse(description="Successfully authenticated - returns user data and JWT tokens"),
+        400: OpenApiResponse(description="Invalid Google token or authentication failed"),
+    }
+)
 class GoogleLoginView(TokenViewBase):
+    """
+    Google OAuth login endpoint.
+    
+    Accepts a Google ID token (token_id), validates it with Google's tokeninfo endpoint,
+    and returns JWT tokens along with user data. If the user doesn't exist, a new account
+    will be created using the Google profile information.
+    
+    Request body:
+    {
+        "token_id": "google_id_token_string"
+    }
+    
+    Response:
+    {
+        "user": {...user_data...},
+        "tokens": {
+            "access": "jwt_access_token",
+            "refresh": "jwt_refresh_token"
+        }
+    }
+    """
     serializer_class = GoogleLoginSerializer
 
 
+@extend_schema(
+    summary="Facebook OAuth Login", 
+    description="Authenticate user using Facebook access token and return JWT access/refresh tokens with user data",
+    tags=["Authentication"],
+    responses={
+        200: OpenApiResponse(description="Successfully authenticated - returns user data and JWT tokens"),
+        400: OpenApiResponse(description="Invalid Facebook token or authentication failed"),
+    }
+)
 class FacebookLoginView(TokenViewBase):
+    """
+    Facebook OAuth login endpoint.
+    
+    Accepts a Facebook access token, validates it with Facebook's debug_token endpoint,
+    and returns JWT tokens along with user data. If the user doesn't exist, a new account
+    will be created using the Facebook profile information.
+    
+    Request body:
+    {
+        "access_token": "facebook_access_token_string"
+    }
+    
+    Response:
+    {
+        "user": {...user_data...},
+        "tokens": {
+            "access": "jwt_access_token", 
+            "refresh": "jwt_refresh_token"
+        }
+    }
+    """
     serializer_class = FacebookLoginSerializer
 
 
+@extend_schema(
+    summary="OpenID Connect Login",
+    description="Authenticate user using OpenID Connect data and return JWT access/refresh tokens with user data", 
+    tags=["Authentication"],
+    responses={
+        200: OpenApiResponse(description="Successfully authenticated - returns user data and JWT tokens"),
+        400: OpenApiResponse(description="Invalid OpenID data or authentication failed"),
+    }
+)
 class OpenIdLoginView(TokenViewBase):
+    """
+    OpenID Connect login endpoint.
+    
+    Accepts OpenID Connect user data (name, email, user_id), creates a NUSNet email format,
+    and returns JWT tokens along with user data. If the user doesn't exist, a new account
+    will be created.
+    
+    Request body:
+    {
+        "name": "User Name",
+        "email": "user@domain.com", 
+        "user_id": "user_identifier"
+    }
+    
+    Response:
+    {
+        "user": {...user_data...},
+        "tokens": {
+            "access": "jwt_access_token",
+            "refresh": "jwt_refresh_token"
+        }
+    }
+    """
     serializer_class = OpenIdLoginSerializer
 
 
+@extend_schema(
+    summary="Password Login",
+    description="Authenticate user using name, email and password, return JWT access/refresh tokens with user data",
+    tags=["Authentication"], 
+    responses={
+        200: OpenApiResponse(description="Successfully authenticated - returns user data and JWT tokens"),
+        400: OpenApiResponse(description="Invalid credentials or authentication failed"),
+    }
+)
 class PasswordLoginView(TokenViewBase):
+    """
+    Traditional email/password login endpoint.
+    
+    Accepts name, email and password credentials and returns JWT tokens along with user data
+    for authenticated users.
+    
+    Request body:
+    {
+        "name": "User Name",
+        "email": "user@example.com",
+        "password": "user_password"
+    }
+    
+    Response:
+    {
+        "user": {...user_data...},
+        "tokens": {
+            "access": "jwt_access_token",
+            "refresh": "jwt_refresh_token"
+        }
+    }
+    """
     serializer_class = PasswordLoginSerializer
 
 
+@extend_schema(
+    summary="Refresh Access Token",
+    description="Refresh an expired access token using a valid refresh token and return user data",
+    tags=["Authentication"],
+    responses={
+        200: OpenApiResponse(description="New access token generated successfully with user data"),
+        400: OpenApiResponse(description="Invalid refresh token"),
+        401: OpenApiResponse(description="Refresh token expired or invalid"),
+    }
+)
 class AccessTokenRefreshView(TokenViewBase):
+    """
+    JWT token refresh endpoint.
+    
+    Accepts a valid refresh token and returns a new access token along with current user data.
+    The refresh token remains valid for future use until it expires.
+    
+    Request body:
+    {
+        "refresh": "jwt_refresh_token"
+    }
+    
+    Response:
+    {
+        "user": {...user_data...},
+        "tokens": {
+            "access": "new_jwt_access_token",
+            "refresh": "jwt_refresh_token"
+        }
+    }
+    """
     serializer_class = AccessTokenRefreshSerializer
 
 
+@extend_schema(
+    summary="Check Account Status",
+    description="Check if an account exists for the given email and return basic account information",
+    tags=["Authentication"],
+    responses={
+        200: OpenApiResponse(description="Account found - returns email and name"),
+        400: OpenApiResponse(description="Account not found (no user or user invite exists)"),
+    }
+)
 class CheckAccountView(TokenViewBase):
+    """
+    Account verification endpoint.
+    
+    Checks if an account exists for the provided email address. Returns basic information
+    if found in either the User or UserInvite models.
+    
+    Request body:
+    {
+        "email": "user@example.com"
+    }
+    
+    Response (if user exists):
+    {
+        "email": "user@example.com",
+        "name": "User Name"
+    }
+    
+    Response (if only user invite exists):
+    {
+        "email": "user@example.com"
+    }
+    """
     serializer_class = CheckAccountSerializer
 
 
+@extend_schema(
+    summary="Password Reset",
+    description="Generate new random password for user and send it via email",
+    tags=["Authentication"],
+    responses={
+        200: OpenApiResponse(description="Password reset successful - new password sent via email"),
+        400: OpenApiResponse(description="User not found with provided email"),
+        500: OpenApiResponse(description="Internal server error during password reset"),
+    }
+)
 class PasswordResetView(TokenViewBase):
+    """
+    Password reset endpoint.
+    
+    Generates a new random 8-character password for the user, deletes any existing
+    password authentication, creates new password authentication, and sends the new
+    password to the user's email.
+    
+    Request body:
+    {
+        "email": "user@example.com"
+    }
+    
+    Response:
+    {
+        "email": "user@example.com",
+        "name": "User Name"
+    }
+    
+    Note: The new password is sent to the user's email address.
+    """
     serializer_class = PasswordResetSerializer

--- a/backend/treeckle/authentication/views.py
+++ b/backend/treeckle/authentication/views.py
@@ -18,23 +18,27 @@ from .serializers import (
     description="Authenticate user using Google ID token and return JWT access/refresh tokens with user data",
     tags=["Authentication"],
     responses={
-        200: OpenApiResponse(description="Successfully authenticated - returns user data and JWT tokens"),
-        400: OpenApiResponse(description="Invalid Google token or authentication failed"),
-    }
+        200: OpenApiResponse(
+            description="Successfully authenticated - returns user data and JWT tokens"
+        ),
+        400: OpenApiResponse(
+            description="Invalid Google token or authentication failed"
+        ),
+    },
 )
 class GoogleLoginView(TokenViewBase):
     """
     Google OAuth login endpoint.
-    
+
     Accepts a Google ID token (token_id), validates it with Google's tokeninfo endpoint,
     and returns JWT tokens along with user data. If the user doesn't exist, a new account
     will be created using the Google profile information.
-    
+
     Request body:
     {
         "token_id": "google_id_token_string"
     }
-    
+
     Response:
     {
         "user": {...user_data...},
@@ -44,67 +48,77 @@ class GoogleLoginView(TokenViewBase):
         }
     }
     """
+
     serializer_class = GoogleLoginSerializer
 
 
 @extend_schema(
-    summary="Facebook OAuth Login", 
+    summary="Facebook OAuth Login",
     description="Authenticate user using Facebook access token and return JWT access/refresh tokens with user data",
     tags=["Authentication"],
     responses={
-        200: OpenApiResponse(description="Successfully authenticated - returns user data and JWT tokens"),
-        400: OpenApiResponse(description="Invalid Facebook token or authentication failed"),
-    }
+        200: OpenApiResponse(
+            description="Successfully authenticated - returns user data and JWT tokens"
+        ),
+        400: OpenApiResponse(
+            description="Invalid Facebook token or authentication failed"
+        ),
+    },
 )
 class FacebookLoginView(TokenViewBase):
     """
     Facebook OAuth login endpoint.
-    
+
     Accepts a Facebook access token, validates it with Facebook's debug_token endpoint,
     and returns JWT tokens along with user data. If the user doesn't exist, a new account
     will be created using the Facebook profile information.
-    
+
     Request body:
     {
         "access_token": "facebook_access_token_string"
     }
-    
+
     Response:
     {
         "user": {...user_data...},
         "tokens": {
-            "access": "jwt_access_token", 
+            "access": "jwt_access_token",
             "refresh": "jwt_refresh_token"
         }
     }
     """
+
     serializer_class = FacebookLoginSerializer
 
 
 @extend_schema(
     summary="OpenID Connect Login",
-    description="Authenticate user using OpenID Connect data and return JWT access/refresh tokens with user data", 
+    description="Authenticate user using OpenID Connect data and return JWT access/refresh tokens with user data",
     tags=["Authentication"],
     responses={
-        200: OpenApiResponse(description="Successfully authenticated - returns user data and JWT tokens"),
-        400: OpenApiResponse(description="Invalid OpenID data or authentication failed"),
-    }
+        200: OpenApiResponse(
+            description="Successfully authenticated - returns user data and JWT tokens"
+        ),
+        400: OpenApiResponse(
+            description="Invalid OpenID data or authentication failed"
+        ),
+    },
 )
 class OpenIdLoginView(TokenViewBase):
     """
     OpenID Connect login endpoint.
-    
+
     Accepts OpenID Connect user data (name, email, user_id), creates a NUSNet email format,
     and returns JWT tokens along with user data. If the user doesn't exist, a new account
     will be created.
-    
+
     Request body:
     {
         "name": "User Name",
-        "email": "user@domain.com", 
+        "email": "user@domain.com",
         "user_id": "user_identifier"
     }
-    
+
     Response:
     {
         "user": {...user_data...},
@@ -114,32 +128,37 @@ class OpenIdLoginView(TokenViewBase):
         }
     }
     """
+
     serializer_class = OpenIdLoginSerializer
 
 
 @extend_schema(
     summary="Password Login",
     description="Authenticate user using name, email and password, return JWT access/refresh tokens with user data",
-    tags=["Authentication"], 
+    tags=["Authentication"],
     responses={
-        200: OpenApiResponse(description="Successfully authenticated - returns user data and JWT tokens"),
-        400: OpenApiResponse(description="Invalid credentials or authentication failed"),
-    }
+        200: OpenApiResponse(
+            description="Successfully authenticated - returns user data and JWT tokens"
+        ),
+        400: OpenApiResponse(
+            description="Invalid credentials or authentication failed"
+        ),
+    },
 )
 class PasswordLoginView(TokenViewBase):
     """
     Traditional email/password login endpoint.
-    
+
     Accepts name, email and password credentials and returns JWT tokens along with user data
     for authenticated users.
-    
+
     Request body:
     {
         "name": "User Name",
         "email": "user@example.com",
         "password": "user_password"
     }
-    
+
     Response:
     {
         "user": {...user_data...},
@@ -149,6 +168,7 @@ class PasswordLoginView(TokenViewBase):
         }
     }
     """
+
     serializer_class = PasswordLoginSerializer
 
 
@@ -157,23 +177,25 @@ class PasswordLoginView(TokenViewBase):
     description="Refresh an expired access token using a valid refresh token and return user data",
     tags=["Authentication"],
     responses={
-        200: OpenApiResponse(description="New access token generated successfully with user data"),
+        200: OpenApiResponse(
+            description="New access token generated successfully with user data"
+        ),
         400: OpenApiResponse(description="Invalid refresh token"),
         401: OpenApiResponse(description="Refresh token expired or invalid"),
-    }
+    },
 )
 class AccessTokenRefreshView(TokenViewBase):
     """
     JWT token refresh endpoint.
-    
+
     Accepts a valid refresh token and returns a new access token along with current user data.
     The refresh token remains valid for future use until it expires.
-    
+
     Request body:
     {
         "refresh": "jwt_refresh_token"
     }
-    
+
     Response:
     {
         "user": {...user_data...},
@@ -183,6 +205,7 @@ class AccessTokenRefreshView(TokenViewBase):
         }
     }
     """
+
     serializer_class = AccessTokenRefreshSerializer
 
 
@@ -192,32 +215,35 @@ class AccessTokenRefreshView(TokenViewBase):
     tags=["Authentication"],
     responses={
         200: OpenApiResponse(description="Account found - returns email and name"),
-        400: OpenApiResponse(description="Account not found (no user or user invite exists)"),
-    }
+        400: OpenApiResponse(
+            description="Account not found (no user or user invite exists)"
+        ),
+    },
 )
 class CheckAccountView(TokenViewBase):
     """
     Account verification endpoint.
-    
+
     Checks if an account exists for the provided email address. Returns basic information
     if found in either the User or UserInvite models.
-    
+
     Request body:
     {
         "email": "user@example.com"
     }
-    
+
     Response (if user exists):
     {
         "email": "user@example.com",
         "name": "User Name"
     }
-    
+
     Response (if only user invite exists):
     {
         "email": "user@example.com"
     }
     """
+
     serializer_class = CheckAccountSerializer
 
 
@@ -226,30 +252,33 @@ class CheckAccountView(TokenViewBase):
     description="Generate new random password for user and send it via email",
     tags=["Authentication"],
     responses={
-        200: OpenApiResponse(description="Password reset successful - new password sent via email"),
+        200: OpenApiResponse(
+            description="Password reset successful - new password sent via email"
+        ),
         400: OpenApiResponse(description="User not found with provided email"),
         500: OpenApiResponse(description="Internal server error during password reset"),
-    }
+    },
 )
 class PasswordResetView(TokenViewBase):
     """
     Password reset endpoint.
-    
+
     Generates a new random 8-character password for the user, deletes any existing
     password authentication, creates new password authentication, and sends the new
     password to the user's email.
-    
+
     Request body:
     {
         "email": "user@example.com"
     }
-    
+
     Response:
     {
         "email": "user@example.com",
         "name": "User Name"
     }
-    
+
     Note: The new password is sent to the user's email address.
     """
+
     serializer_class = PasswordResetSerializer

--- a/backend/treeckle/bookings/tests.py
+++ b/backend/treeckle/bookings/tests.py
@@ -1,2 +1,1 @@
-
 # Create your tests here.

--- a/backend/treeckle/bookings/views.py
+++ b/backend/treeckle/bookings/views.py
@@ -6,6 +6,9 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework.permissions import AllowAny
 
+from drf_spectacular.utils import extend_schema, extend_schema_view, OpenApiParameter
+from drf_spectacular.openapi import OpenApiResponse, OpenApiTypes
+
 from treeckle.common.exceptions import BadRequest
 from treeckle.common.parsers import parse_ms_timestamp_to_datetime
 from email_service.logic import send_created_booking_emails, send_updated_booking_emails
@@ -32,7 +35,26 @@ from .middlewares import check_requester_booking_same_organization
 
 
 # Create your views here.
+@extend_schema_view(
+    get=extend_schema(
+        summary="Get Total Booking Count",
+        description="Get the total number of bookings across all organizations (public endpoint)",
+        tags=["Bookings - Statistics"],
+        responses={
+            200: OpenApiResponse(description="Total booking count returned successfully"),
+        }
+    )
+)
 class TotalBookingCountView(APIView):
+    """
+    Public endpoint to get total booking count.
+    
+    Returns the total number of bookings across all organizations.
+    This is a public endpoint that doesn't require authentication.
+    
+    Response:
+    - Integer representing total booking count
+    """
     permission_classes = [AllowAny]
 
     def get(self, request):
@@ -41,7 +63,27 @@ class TotalBookingCountView(APIView):
         return Response(data, status=status.HTTP_200_OK)
 
 
+@extend_schema_view(
+    get=extend_schema(
+        summary="Get Pending Booking Count",
+        description="Get the count of pending bookings for the admin's organization",
+        tags=["Bookings - Statistics"],
+        responses={
+            200: OpenApiResponse(description="Pending booking count returned successfully"),
+            403: OpenApiResponse(description="Admin access required"),
+        }
+    )
+)
 class PendingBookingCountView(APIView):
+    """
+    Admin endpoint to get pending booking count.
+    
+    Returns the number of bookings with PENDING status within the admin's organization.
+    Requires admin role access.
+    
+    Response:
+    - Integer representing pending booking count for the organization
+    """
     @check_access(Role.ADMIN)
     def get(self, request, requester: User):
         data = get_bookings(
@@ -51,7 +93,86 @@ class PendingBookingCountView(APIView):
         return Response(data, status=status.HTTP_200_OK)
 
 
+@extend_schema_view(
+    get=extend_schema(
+        summary="Get Bookings",
+        description="Retrieve bookings with optional filtering by user, venue, date range, and status",
+        tags=["Bookings"],
+        parameters=[
+            OpenApiParameter(
+                name="user_id",
+                type=OpenApiTypes.INT,
+                location=OpenApiParameter.QUERY,
+                description="Filter bookings by user ID",
+                required=False
+            ),
+            OpenApiParameter(
+                name="venue_id", 
+                type=OpenApiTypes.INT,
+                location=OpenApiParameter.QUERY,
+                description="Filter bookings by venue ID",
+                required=False
+            ),
+            OpenApiParameter(
+                name="start_date_time",
+                type=OpenApiTypes.INT,
+                location=OpenApiParameter.QUERY, 
+                description="Filter bookings starting from this timestamp (milliseconds)",
+                required=False
+            ),
+            OpenApiParameter(
+                name="end_date_time",
+                type=OpenApiTypes.INT,
+                location=OpenApiParameter.QUERY,
+                description="Filter bookings ending before this timestamp (milliseconds)", 
+                required=False
+            ),
+            OpenApiParameter(
+                name="statuses",
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.QUERY,
+                description="Comma-separated list of booking statuses (PENDING,APPROVED,REJECTED,CANCELLED)",
+                required=False
+            ),
+            OpenApiParameter(
+                name="full_details",
+                type=OpenApiTypes.BOOL,
+                location=OpenApiParameter.QUERY,
+                description="Whether to return full booking details",
+                required=False
+            ),
+        ],
+        responses={
+            200: OpenApiResponse(description="List of bookings returned successfully"),
+            400: OpenApiResponse(description="Invalid query parameters"),
+            403: OpenApiResponse(description="Insufficient permissions"),
+        }
+    ),
+    post=extend_schema(
+        summary="Create New Booking",
+        description="Create one or more bookings for specified date/time ranges at a venue",
+        tags=["Bookings"],
+        responses={
+            201: OpenApiResponse(description="Bookings created successfully"),
+            400: OpenApiResponse(description="Invalid booking data or venue not found"),
+            403: OpenApiResponse(description="Insufficient permissions"),
+        }
+    )
+)
 class BookingsView(APIView):
+    """
+    Bookings management endpoint.
+    
+    GET: Retrieve bookings with optional filtering
+    - Supports filtering by user_id, venue_id, date range, statuses
+    - Returns basic or full details based on full_details parameter
+    - Accessible by residents, organizers, and admins
+    
+    POST: Create new bookings
+    - Creates bookings for multiple date/time ranges at once
+    - Sends notification emails to relevant parties
+    - Returns the created booking objects
+    """
     @check_access(Role.RESIDENT, Role.ORGANIZER, Role.ADMIN)
     def get(self, request, requester: User):
         query_params = request.query_params.dict()
@@ -88,8 +209,8 @@ class BookingsView(APIView):
 
         data = [
             booking_to_json(booking, full_details=full_details) for booking in bookings
-        ]
-
+        ]        
+        
         return Response(data, status=status.HTTP_200_OK)
 
     @check_access(Role.RESIDENT, Role.ORGANIZER, Role.ADMIN)
@@ -129,12 +250,62 @@ class BookingsView(APIView):
 
         send_created_booking_emails(bookings=new_bookings)
 
-        data = [booking_to_json(booking) for booking in new_bookings]
-
+        data = [booking_to_json(booking) for booking in new_bookings]        
+        
         return Response(data, status=status.HTTP_201_CREATED)
 
 
+@extend_schema_view(
+    get=extend_schema(
+        summary="Get Single Booking Details",
+        description="Retrieve detailed information for a specific booking",
+        tags=["Bookings"],
+        responses={
+            200: OpenApiResponse(description="Booking details returned successfully"),
+            403: OpenApiResponse(description="Insufficient permissions - must be booker or admin"),
+            404: OpenApiResponse(description="Booking not found or not in same organization"),
+        }
+    ),
+    patch=extend_schema(
+        summary="Update Booking Status", 
+        description="Update the status of a booking (approve, reject, cancel, revoke)",
+        tags=["Bookings"],
+        responses={
+            200: OpenApiResponse(description="Booking status updated successfully"),
+            400: OpenApiResponse(description="Invalid action for current booking status"),
+            403: OpenApiResponse(description="Insufficient permissions - must be booker or admin"),
+            404: OpenApiResponse(description="Booking not found or not in same organization"),
+        }
+    ),
+    delete=extend_schema(
+        summary="Delete Booking",
+        description="Permanently delete a booking (admin only)",
+        tags=["Bookings"],
+        responses={
+            200: OpenApiResponse(description="Booking deleted successfully"),
+            403: OpenApiResponse(description="Admin access required"),
+            404: OpenApiResponse(description="Booking not found or not in same organization"),
+        }
+    )
+)
 class SingleBookingView(APIView):
+    """
+    Individual booking management endpoint.
+    
+    GET: Retrieve full details of a specific booking
+    - Returns complete booking information
+    - Accessible by booking creator or organization admins
+    
+    PATCH: Update booking status
+    - Actions: APPROVE, REJECT, CANCEL, REVOKE
+    - Sends notification emails for status changes
+    - Returns updated booking(s) information
+    
+    DELETE: Delete booking (admin only)
+    - Permanently removes the booking
+    - Returns the deleted booking data
+    - Admin access required
+    """
     @check_access(Role.RESIDENT, Role.ORGANIZER, Role.ADMIN)
     @check_requester_booking_same_organization
     @check_requester_is_booker_or_admin

--- a/backend/treeckle/bookings/views.py
+++ b/backend/treeckle/bookings/views.py
@@ -41,20 +41,23 @@ from .middlewares import check_requester_booking_same_organization
         description="Get the total number of bookings across all organizations (public endpoint)",
         tags=["Bookings - Statistics"],
         responses={
-            200: OpenApiResponse(description="Total booking count returned successfully"),
-        }
+            200: OpenApiResponse(
+                description="Total booking count returned successfully"
+            ),
+        },
     )
 )
 class TotalBookingCountView(APIView):
     """
     Public endpoint to get total booking count.
-    
+
     Returns the total number of bookings across all organizations.
     This is a public endpoint that doesn't require authentication.
-    
+
     Response:
     - Integer representing total booking count
     """
+
     permission_classes = [AllowAny]
 
     def get(self, request):
@@ -69,21 +72,24 @@ class TotalBookingCountView(APIView):
         description="Get the count of pending bookings for the admin's organization",
         tags=["Bookings - Statistics"],
         responses={
-            200: OpenApiResponse(description="Pending booking count returned successfully"),
+            200: OpenApiResponse(
+                description="Pending booking count returned successfully"
+            ),
             403: OpenApiResponse(description="Admin access required"),
-        }
+        },
     )
 )
 class PendingBookingCountView(APIView):
     """
     Admin endpoint to get pending booking count.
-    
+
     Returns the number of bookings with PENDING status within the admin's organization.
     Requires admin role access.
-    
+
     Response:
     - Integer representing pending booking count for the organization
     """
+
     @check_access(Role.ADMIN)
     def get(self, request, requester: User):
         data = get_bookings(
@@ -104,49 +110,49 @@ class PendingBookingCountView(APIView):
                 type=OpenApiTypes.INT,
                 location=OpenApiParameter.QUERY,
                 description="Filter bookings by user ID",
-                required=False
+                required=False,
             ),
             OpenApiParameter(
-                name="venue_id", 
+                name="venue_id",
                 type=OpenApiTypes.INT,
                 location=OpenApiParameter.QUERY,
                 description="Filter bookings by venue ID",
-                required=False
+                required=False,
             ),
             OpenApiParameter(
                 name="start_date_time",
                 type=OpenApiTypes.INT,
-                location=OpenApiParameter.QUERY, 
+                location=OpenApiParameter.QUERY,
                 description="Filter bookings starting from this timestamp (milliseconds)",
-                required=False
+                required=False,
             ),
             OpenApiParameter(
                 name="end_date_time",
                 type=OpenApiTypes.INT,
                 location=OpenApiParameter.QUERY,
-                description="Filter bookings ending before this timestamp (milliseconds)", 
-                required=False
+                description="Filter bookings ending before this timestamp (milliseconds)",
+                required=False,
             ),
             OpenApiParameter(
                 name="statuses",
                 type=OpenApiTypes.STR,
                 location=OpenApiParameter.QUERY,
                 description="Comma-separated list of booking statuses (PENDING,APPROVED,REJECTED,CANCELLED)",
-                required=False
+                required=False,
             ),
             OpenApiParameter(
                 name="full_details",
                 type=OpenApiTypes.BOOL,
                 location=OpenApiParameter.QUERY,
                 description="Whether to return full booking details",
-                required=False
+                required=False,
             ),
         ],
         responses={
             200: OpenApiResponse(description="List of bookings returned successfully"),
             400: OpenApiResponse(description="Invalid query parameters"),
             403: OpenApiResponse(description="Insufficient permissions"),
-        }
+        },
     ),
     post=extend_schema(
         summary="Create New Booking",
@@ -156,23 +162,24 @@ class PendingBookingCountView(APIView):
             201: OpenApiResponse(description="Bookings created successfully"),
             400: OpenApiResponse(description="Invalid booking data or venue not found"),
             403: OpenApiResponse(description="Insufficient permissions"),
-        }
-    )
+        },
+    ),
 )
 class BookingsView(APIView):
     """
     Bookings management endpoint.
-    
+
     GET: Retrieve bookings with optional filtering
     - Supports filtering by user_id, venue_id, date range, statuses
     - Returns basic or full details based on full_details parameter
     - Accessible by residents, organizers, and admins
-    
+
     POST: Create new bookings
     - Creates bookings for multiple date/time ranges at once
     - Sends notification emails to relevant parties
     - Returns the created booking objects
     """
+
     @check_access(Role.RESIDENT, Role.ORGANIZER, Role.ADMIN)
     def get(self, request, requester: User):
         query_params = request.query_params.dict()
@@ -209,8 +216,8 @@ class BookingsView(APIView):
 
         data = [
             booking_to_json(booking, full_details=full_details) for booking in bookings
-        ]        
-        
+        ]
+
         return Response(data, status=status.HTTP_200_OK)
 
     @check_access(Role.RESIDENT, Role.ORGANIZER, Role.ADMIN)
@@ -250,8 +257,8 @@ class BookingsView(APIView):
 
         send_created_booking_emails(bookings=new_bookings)
 
-        data = [booking_to_json(booking) for booking in new_bookings]        
-        
+        data = [booking_to_json(booking) for booking in new_bookings]
+
         return Response(data, status=status.HTTP_201_CREATED)
 
 
@@ -262,20 +269,30 @@ class BookingsView(APIView):
         tags=["Bookings"],
         responses={
             200: OpenApiResponse(description="Booking details returned successfully"),
-            403: OpenApiResponse(description="Insufficient permissions - must be booker or admin"),
-            404: OpenApiResponse(description="Booking not found or not in same organization"),
-        }
+            403: OpenApiResponse(
+                description="Insufficient permissions - must be booker or admin"
+            ),
+            404: OpenApiResponse(
+                description="Booking not found or not in same organization"
+            ),
+        },
     ),
     patch=extend_schema(
-        summary="Update Booking Status", 
+        summary="Update Booking Status",
         description="Update the status of a booking (approve, reject, cancel, revoke)",
         tags=["Bookings"],
         responses={
             200: OpenApiResponse(description="Booking status updated successfully"),
-            400: OpenApiResponse(description="Invalid action for current booking status"),
-            403: OpenApiResponse(description="Insufficient permissions - must be booker or admin"),
-            404: OpenApiResponse(description="Booking not found or not in same organization"),
-        }
+            400: OpenApiResponse(
+                description="Invalid action for current booking status"
+            ),
+            403: OpenApiResponse(
+                description="Insufficient permissions - must be booker or admin"
+            ),
+            404: OpenApiResponse(
+                description="Booking not found or not in same organization"
+            ),
+        },
     ),
     delete=extend_schema(
         summary="Delete Booking",
@@ -284,28 +301,31 @@ class BookingsView(APIView):
         responses={
             200: OpenApiResponse(description="Booking deleted successfully"),
             403: OpenApiResponse(description="Admin access required"),
-            404: OpenApiResponse(description="Booking not found or not in same organization"),
-        }
-    )
+            404: OpenApiResponse(
+                description="Booking not found or not in same organization"
+            ),
+        },
+    ),
 )
 class SingleBookingView(APIView):
     """
     Individual booking management endpoint.
-    
+
     GET: Retrieve full details of a specific booking
     - Returns complete booking information
     - Accessible by booking creator or organization admins
-    
+
     PATCH: Update booking status
     - Actions: APPROVE, REJECT, CANCEL, REVOKE
     - Sends notification emails for status changes
     - Returns updated booking(s) information
-    
+
     DELETE: Delete booking (admin only)
     - Permanently removes the booking
     - Returns the deleted booking data
     - Admin access required
     """
+
     @check_access(Role.RESIDENT, Role.ORGANIZER, Role.ADMIN)
     @check_requester_booking_same_organization
     @check_requester_is_booker_or_admin

--- a/backend/treeckle/comments/tests.py
+++ b/backend/treeckle/comments/tests.py
@@ -1,2 +1,1 @@
-
 # Create your tests here.

--- a/backend/treeckle/comments/views.py
+++ b/backend/treeckle/comments/views.py
@@ -36,7 +36,7 @@ from .logic import (
                 name="booking_id",
                 type=int,
                 location=OpenApiParameter.PATH,
-                description="The ID of the booking to retrieve comments for"
+                description="The ID of the booking to retrieve comments for",
             )
         ],
         responses={
@@ -55,18 +55,18 @@ from .logic import (
                             "profileImage": "https://example.com/profile.jpg",
                             "isSelf": False,
                             "createdAt": 1647875400000,
-                            "updatedAt": 1647875400000
+                            "updatedAt": 1647875400000,
                         },
                         "isActive": True,
                         "createdAt": 1647875400000,
-                        "updatedAt": 1647875400000
+                        "updatedAt": 1647875400000,
                     }
-                ]
+                ],
             },
             401: {"description": "Authentication required"},
             403: {"description": "Access denied - must be booker or admin"},
-            404: {"description": "Booking not found or not in same organization"}
-        }
+            404: {"description": "Booking not found or not in same organization"},
+        },
     ),
     post=extend_schema(
         summary="Create Booking Comment",
@@ -77,14 +77,12 @@ from .logic import (
                 name="booking_id",
                 type=int,
                 location=OpenApiParameter.PATH,
-                description="The ID of the booking to add a comment to"
+                description="The ID of the booking to add a comment to",
             )
         ],
         request={
             "application/json": {
-                "example": {
-                    "content": "This is a new comment on the booking"
-                }
+                "example": {"content": "This is a new comment on the booking"}
             }
         },
         responses={
@@ -102,20 +100,20 @@ from .logic import (
                         "profileImage": None,
                         "isSelf": True,
                         "createdAt": 1647875300000,
-                        "updatedAt": 1647875300000
+                        "updatedAt": 1647875300000,
                     },
                     "isActive": True,
                     "createdAt": 1647875500000,
-                    "updatedAt": 1647875500000
-                }
+                    "updatedAt": 1647875500000,
+                },
             },
             400: {"description": "Invalid comment data"},
             401: {"description": "Authentication required"},
             403: {"description": "Access denied - must be booker or admin"},
             404: {"description": "Booking not found or not in same organization"},
-            500: {"description": "Internal server error while creating comment"}
-        }
-    )
+            500: {"description": "Internal server error while creating comment"},
+        },
+    ),
 )
 # Not used
 class BookingCommentsView(APIView):
@@ -125,7 +123,7 @@ class BookingCommentsView(APIView):
     def get(self, request, requester: User, booking: Booking):
         """
         Retrieve all comments for a specific booking.
-        
+
         Returns a list of comments associated with the booking, including
         commenter information. Only accessible by the booker or admins.
         """
@@ -148,7 +146,7 @@ class BookingCommentsView(APIView):
     def post(self, request, requester: User, booking: Booking):
         """
         Create a new comment on a booking.
-        
+
         Allows the booker or admins to add comments to the booking.
         The comment will be associated with the requester as the commenter.
         """
@@ -180,14 +178,12 @@ class BookingCommentsView(APIView):
                 name="comment_id",
                 type=int,
                 location=OpenApiParameter.PATH,
-                description="The ID of the comment to update"
+                description="The ID of the comment to update",
             )
         ],
         request={
             "application/json": {
-                "example": {
-                    "content": "This is the updated comment content"
-                }
+                "example": {"content": "This is the updated comment content"}
             }
         },
         responses={
@@ -205,18 +201,18 @@ class BookingCommentsView(APIView):
                         "profileImage": None,
                         "isSelf": True,
                         "createdAt": 1647875400000,
-                        "updatedAt": 1647875400000
+                        "updatedAt": 1647875400000,
                     },
                     "isActive": True,
                     "createdAt": 1647875400000,
-                    "updatedAt": 1647875600000
-                }
+                    "updatedAt": 1647875600000,
+                },
             },
             400: {"description": "Invalid comment data"},
             401: {"description": "Authentication required"},
             403: {"description": "Access denied - only commenter can update"},
-            404: {"description": "Comment not found or inactive"}
-        }
+            404: {"description": "Comment not found or inactive"},
+        },
     ),
     delete=extend_schema(
         summary="Delete Comment",
@@ -227,7 +223,7 @@ class BookingCommentsView(APIView):
                 name="comment_id",
                 type=int,
                 location=OpenApiParameter.PATH,
-                description="The ID of the comment to delete"
+                description="The ID of the comment to delete",
             )
         ],
         responses={
@@ -245,19 +241,19 @@ class BookingCommentsView(APIView):
                         "profileImage": None,
                         "isSelf": True,
                         "createdAt": 1647875400000,
-                        "updatedAt": 1647875400000
+                        "updatedAt": 1647875400000,
                     },
                     "isActive": False,
                     "createdAt": 1647875400000,
-                    "updatedAt": 1647875700000
-                }
+                    "updatedAt": 1647875700000,
+                },
             },
             401: {"description": "Authentication required"},
             403: {"description": "Access denied - only commenter can delete"},
             404: {"description": "Comment not found or inactive"},
-            500: {"description": "Internal server error while deleting comment"}
-        }
-    )
+            500: {"description": "Internal server error while deleting comment"},
+        },
+    ),
 )
 class SingleCommentView(APIView):
     @check_access(Role.RESIDENT, Role.ORGANIZER, Role.ADMIN)
@@ -266,7 +262,7 @@ class SingleCommentView(APIView):
     def put(self, request, requester: User, comment: Comment):
         """
         Update the content of an existing comment.
-        
+
         Allows the original commenter to modify their comment content.
         Only active comments can be updated.
         """
@@ -286,7 +282,7 @@ class SingleCommentView(APIView):
     def delete(self, request, requester: User, comment: Comment):
         """
         Soft delete a comment by marking it as inactive.
-        
+
         The comment content will be replaced with a deletion message
         but the comment record is preserved for audit purposes.
         """
@@ -304,13 +300,7 @@ class SingleCommentView(APIView):
         summary="Mark Comments as Read",
         description="Mark multiple comments as read by the current user. Creates read records for comment tracking.",
         tags=["Comment Reads"],
-        request={
-            "application/json": {
-                "example": {
-                    "comment_ids": [1, 2, 3, 5, 8]
-                }
-            }
-        },
+        request={"application/json": {"example": {"comment_ids": [1, 2, 3, 5, 8]}}},
         responses={
             201: {
                 "description": "Comments marked as read successfully",
@@ -327,11 +317,11 @@ class SingleCommentView(APIView):
                             "profileImage": None,
                             "isSelf": False,
                             "createdAt": 1647875300000,
-                            "updatedAt": 1647875300000
+                            "updatedAt": 1647875300000,
                         },
                         "isActive": True,
                         "createdAt": 1647875400000,
-                        "updatedAt": 1647875400000
+                        "updatedAt": 1647875400000,
                     },
                     {
                         "id": 2,
@@ -345,17 +335,17 @@ class SingleCommentView(APIView):
                             "profileImage": "https://example.com/bob.jpg",
                             "isSelf": False,
                             "createdAt": 1647875200000,
-                            "updatedAt": 1647875200000
+                            "updatedAt": 1647875200000,
                         },
                         "isActive": True,
                         "createdAt": 1647875500000,
-                        "updatedAt": 1647875500000
-                    }
-                ]
+                        "updatedAt": 1647875500000,
+                    },
+                ],
             },
             400: {"description": "Invalid comment IDs data"},
-            401: {"description": "Authentication required"}
-        }
+            401: {"description": "Authentication required"},
+        },
     )
 )
 class ReadCommentsView(APIView):
@@ -363,7 +353,7 @@ class ReadCommentsView(APIView):
     def post(self, request, requester: User):
         """
         Mark multiple comments as read by the current user.
-        
+
         Creates CommentRead records to track which comments have been
         read by the user. Used for notification and unread count features.
         """

--- a/backend/treeckle/comments/views.py
+++ b/backend/treeckle/comments/views.py
@@ -1,6 +1,7 @@
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
+from drf_spectacular.utils import extend_schema, extend_schema_view, OpenApiParameter
 
 from treeckle.common.exceptions import InternalServerError
 from users.permission_middlewares import check_access
@@ -25,12 +26,109 @@ from .logic import (
 # Create your views here.
 
 
+@extend_schema_view(
+    get=extend_schema(
+        summary="List Booking Comments",
+        description="Retrieve all comments for a specific booking. Only accessible by the booker or admins within the same organization.",
+        tags=["Booking Comments"],
+        parameters=[
+            OpenApiParameter(
+                name="booking_id",
+                type=int,
+                location=OpenApiParameter.PATH,
+                description="The ID of the booking to retrieve comments for"
+            )
+        ],
+        responses={
+            200: {
+                "description": "List of booking comments retrieved successfully",
+                "example": [
+                    {
+                        "id": 1,
+                        "content": "This is a sample comment",
+                        "commenter": {
+                            "id": 2,
+                            "name": "John Doe",
+                            "email": "john@example.com",
+                            "organization": "Test Organization",
+                            "role": "RESIDENT",
+                            "profileImage": "https://example.com/profile.jpg",
+                            "isSelf": False,
+                            "createdAt": 1647875400000,
+                            "updatedAt": 1647875400000
+                        },
+                        "isActive": True,
+                        "createdAt": 1647875400000,
+                        "updatedAt": 1647875400000
+                    }
+                ]
+            },
+            401: {"description": "Authentication required"},
+            403: {"description": "Access denied - must be booker or admin"},
+            404: {"description": "Booking not found or not in same organization"}
+        }
+    ),
+    post=extend_schema(
+        summary="Create Booking Comment",
+        description="Add a new comment to a booking. Only accessible by the booker or admins within the same organization.",
+        tags=["Booking Comments"],
+        parameters=[
+            OpenApiParameter(
+                name="booking_id",
+                type=int,
+                location=OpenApiParameter.PATH,
+                description="The ID of the booking to add a comment to"
+            )
+        ],
+        request={
+            "application/json": {
+                "example": {
+                    "content": "This is a new comment on the booking"
+                }
+            }
+        },
+        responses={
+            201: {
+                "description": "Comment created successfully",
+                "example": {
+                    "id": 2,
+                    "content": "This is a new comment on the booking",
+                    "commenter": {
+                        "id": 1,
+                        "name": "Jane Smith",
+                        "email": "jane@example.com",
+                        "organization": "Test Organization",
+                        "role": "ADMIN",
+                        "profileImage": None,
+                        "isSelf": True,
+                        "createdAt": 1647875300000,
+                        "updatedAt": 1647875300000
+                    },
+                    "isActive": True,
+                    "createdAt": 1647875500000,
+                    "updatedAt": 1647875500000
+                }
+            },
+            400: {"description": "Invalid comment data"},
+            401: {"description": "Authentication required"},
+            403: {"description": "Access denied - must be booker or admin"},
+            404: {"description": "Booking not found or not in same organization"},
+            500: {"description": "Internal server error while creating comment"}
+        }
+    )
+)
 # Not used
 class BookingCommentsView(APIView):
     @check_access(Role.RESIDENT, Role.ORGANIZER, Role.ADMIN)
     @check_requester_booking_same_organization
     @check_requester_is_booker_or_admin
     def get(self, request, requester: User, booking: Booking):
+        """
+        Retrieve all comments for a specific booking.
+        
+        Returns a list of comments associated with the booking, including
+        commenter information. Only accessible by the booker or admins.
+        """
         booking_comments = get_booking_comments(booking=booking).select_related(
             "comment__commenter__organization",
             "comment__commenter__profile_image",
@@ -48,6 +146,12 @@ class BookingCommentsView(APIView):
     @check_requester_booking_same_organization
     @check_requester_is_booker_or_admin
     def post(self, request, requester: User, booking: Booking):
+        """
+        Create a new comment on a booking.
+        
+        Allows the booker or admins to add comments to the booking.
+        The comment will be associated with the requester as the commenter.
+        """
         serializer = PostCommentSerializer(data=request.data)
 
         serializer.is_valid(raise_exception=True)
@@ -66,11 +170,106 @@ class BookingCommentsView(APIView):
         return Response(data, status=status.HTTP_201_CREATED)
 
 
+@extend_schema_view(
+    put=extend_schema(
+        summary="Update Comment",
+        description="Update the content of an existing comment. Only the commenter can update their own active comments.",
+        tags=["Comments"],
+        parameters=[
+            OpenApiParameter(
+                name="comment_id",
+                type=int,
+                location=OpenApiParameter.PATH,
+                description="The ID of the comment to update"
+            )
+        ],
+        request={
+            "application/json": {
+                "example": {
+                    "content": "This is the updated comment content"
+                }
+            }
+        },
+        responses={
+            200: {
+                "description": "Comment updated successfully",
+                "example": {
+                    "id": 1,
+                    "content": "This is the updated comment content",
+                    "commenter": {
+                        "id": 2,
+                        "name": "John Doe",
+                        "email": "john@example.com",
+                        "organization": "Test Organization",
+                        "role": "RESIDENT",
+                        "profileImage": None,
+                        "isSelf": True,
+                        "createdAt": 1647875400000,
+                        "updatedAt": 1647875400000
+                    },
+                    "isActive": True,
+                    "createdAt": 1647875400000,
+                    "updatedAt": 1647875600000
+                }
+            },
+            400: {"description": "Invalid comment data"},
+            401: {"description": "Authentication required"},
+            403: {"description": "Access denied - only commenter can update"},
+            404: {"description": "Comment not found or inactive"}
+        }
+    ),
+    delete=extend_schema(
+        summary="Delete Comment",
+        description="Soft delete a comment by marking it as inactive. Only the commenter can delete their own active comments.",
+        tags=["Comments"],
+        parameters=[
+            OpenApiParameter(
+                name="comment_id",
+                type=int,
+                location=OpenApiParameter.PATH,
+                description="The ID of the comment to delete"
+            )
+        ],
+        responses={
+            200: {
+                "description": "Comment deleted successfully",
+                "example": {
+                    "id": 1,
+                    "content": "This comment has been deleted.",
+                    "commenter": {
+                        "id": 2,
+                        "name": "John Doe",
+                        "email": "john@example.com",
+                        "organization": "Test Organization",
+                        "role": "RESIDENT",
+                        "profileImage": None,
+                        "isSelf": True,
+                        "createdAt": 1647875400000,
+                        "updatedAt": 1647875400000
+                    },
+                    "isActive": False,
+                    "createdAt": 1647875400000,
+                    "updatedAt": 1647875700000
+                }
+            },
+            401: {"description": "Authentication required"},
+            403: {"description": "Access denied - only commenter can delete"},
+            404: {"description": "Comment not found or inactive"},
+            500: {"description": "Internal server error while deleting comment"}
+        }
+    )
+)
 class SingleCommentView(APIView):
     @check_access(Role.RESIDENT, Role.ORGANIZER, Role.ADMIN)
     @check_requester_is_commenter
     @check_comment_is_active
     def put(self, request, requester: User, comment: Comment):
+        """
+        Update the content of an existing comment.
+        
+        Allows the original commenter to modify their comment content.
+        Only active comments can be updated.
+        """
         serializer = PostCommentSerializer(data=request.data)
 
         serializer.is_valid(raise_exception=True)
@@ -85,6 +284,12 @@ class SingleCommentView(APIView):
     @check_requester_is_commenter
     @check_comment_is_active
     def delete(self, request, requester: User, comment: Comment):
+        """
+        Soft delete a comment by marking it as inactive.
+        
+        The comment content will be replaced with a deletion message
+        but the comment record is preserved for audit purposes.
+        """
         try:
             deleted_comment = delete_comment(comment=comment)
         except Exception as e:
@@ -94,9 +299,74 @@ class SingleCommentView(APIView):
         return Response(data, status=status.HTTP_200_OK)
 
 
+@extend_schema_view(
+    post=extend_schema(
+        summary="Mark Comments as Read",
+        description="Mark multiple comments as read by the current user. Creates read records for comment tracking.",
+        tags=["Comment Reads"],
+        request={
+            "application/json": {
+                "example": {
+                    "comment_ids": [1, 2, 3, 5, 8]
+                }
+            }
+        },
+        responses={
+            201: {
+                "description": "Comments marked as read successfully",
+                "example": [
+                    {
+                        "id": 1,
+                        "content": "First comment content",
+                        "commenter": {
+                            "id": 2,
+                            "name": "Jane Doe",
+                            "email": "jane@example.com",
+                            "organization": "Test Organization",
+                            "role": "RESIDENT",
+                            "profileImage": None,
+                            "isSelf": False,
+                            "createdAt": 1647875300000,
+                            "updatedAt": 1647875300000
+                        },
+                        "isActive": True,
+                        "createdAt": 1647875400000,
+                        "updatedAt": 1647875400000
+                    },
+                    {
+                        "id": 2,
+                        "content": "Second comment content",
+                        "commenter": {
+                            "id": 3,
+                            "name": "Bob Smith",
+                            "email": "bob@example.com",
+                            "organization": "Test Organization",
+                            "role": "ORGANIZER",
+                            "profileImage": "https://example.com/bob.jpg",
+                            "isSelf": False,
+                            "createdAt": 1647875200000,
+                            "updatedAt": 1647875200000
+                        },
+                        "isActive": True,
+                        "createdAt": 1647875500000,
+                        "updatedAt": 1647875500000
+                    }
+                ]
+            },
+            400: {"description": "Invalid comment IDs data"},
+            401: {"description": "Authentication required"}
+        }
+    )
+)
 class ReadCommentsView(APIView):
     @check_access(Role.RESIDENT, Role.ORGANIZER, Role.ADMIN)
     def post(self, request, requester: User):
+        """
+        Mark multiple comments as read by the current user.
+        
+        Creates CommentRead records to track which comments have been
+        read by the user. Used for notification and unread count features.
+        """
         serializer = PostReadCommentSerializer(data=request.data)
 
         serializer.is_valid(raise_exception=True)

--- a/backend/treeckle/content_delivery_service/tests.py
+++ b/backend/treeckle/content_delivery_service/tests.py
@@ -1,2 +1,1 @@
-
 # Create your tests here.

--- a/backend/treeckle/content_delivery_service/views.py
+++ b/backend/treeckle/content_delivery_service/views.py
@@ -1,2 +1,1 @@
-
 # Create your views here.

--- a/backend/treeckle/email_service/admin.py
+++ b/backend/treeckle/email_service/admin.py
@@ -1,2 +1,1 @@
-
 # Register your models here.

--- a/backend/treeckle/email_service/models.py
+++ b/backend/treeckle/email_service/models.py
@@ -1,2 +1,1 @@
-
 # Create your models here.

--- a/backend/treeckle/email_service/tests.py
+++ b/backend/treeckle/email_service/tests.py
@@ -1,2 +1,1 @@
-
 # Create your tests here.

--- a/backend/treeckle/email_service/views.py
+++ b/backend/treeckle/email_service/views.py
@@ -1,2 +1,1 @@
-
 # Create your views here.

--- a/backend/treeckle/events/tests.py
+++ b/backend/treeckle/events/tests.py
@@ -1,2 +1,1 @@
-
 # Create your tests here.

--- a/backend/treeckle/events/views/event.py
+++ b/backend/treeckle/events/views/event.py
@@ -3,6 +3,7 @@ from django.db.models import Prefetch
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
+from drf_spectacular.utils import extend_schema, extend_schema_view, OpenApiParameter
 
 from treeckle.common.parsers import parse_ms_timestamp_to_datetime
 from treeckle.common.constants import EVENT, SIGN_UPS
@@ -26,9 +27,35 @@ from events.middlewares import (
 )
 
 
+@extend_schema_view(
+    get=extend_schema(
+        summary="Get Event Category Types",
+        description="Retrieve all available event category types within the user's organization. Accessible by residents, organizers, and admins.",
+        responses={
+            200: {
+                "description": "List of event category types",
+                "example": [
+                    "Sports",
+                    "Academic",
+                    "Social",
+                    "Workshop"
+                ]
+            },
+            401: {"description": "Authentication required"},
+            403: {"description": "Insufficient permissions"}
+        },
+        tags=["Events"]
+    )
+)
 class EventCategoryTypesView(APIView):
     @check_access(Role.RESIDENT, Role.ORGANIZER, Role.ADMIN)
     def get(self, request, requester: User):
+        """
+        Get all event category types available in the user's organization.
+        
+        Returns a list of category type names that can be used when creating or filtering events.
+        Only includes category types from the same organization as the requesting user.
+        """
         same_organization_event_category_types = get_event_category_types(
             organization=requester.organization
         )
@@ -41,9 +68,96 @@ class EventCategoryTypesView(APIView):
         return Response(data, status=status.HTTP_200_OK)
 
 
+@extend_schema_view(
+    get=extend_schema(
+        summary="Get All Events",
+        description="Retrieve all events within the organization. Admin-only access. Returns comprehensive event details including sign-ups and categories.",
+        responses={
+            200: {
+                "description": "List of all organization events with complete details",
+                "example": [
+                    {
+                        "id": 1,
+                        "title": "Annual Sports Day",
+                        "creator": {
+                            "id": 2,
+                            "name": "John Organizer",
+                            "profile_image_url": "https://example.com/image.jpg"
+                        },
+                        "organized_by": "Sports Committee",
+                        "venue_name": "Sports Complex",
+                        "description": "Join us for a day of exciting sports activities and competitions.",
+                        "capacity": 100,
+                        "start_date_time": 1735689600000,
+                        "end_date_time": 1735776000000,
+                        "image_url": "https://example.com/event-image.jpg",
+                        "is_published": True,
+                        "is_sign_up_allowed": True,
+                        "is_sign_up_approval_required": False,
+                        "categories": ["Sports", "Recreation"],
+                        "sign_up_count": 45,
+                        "can_modify": True,
+                        "can_view_sign_ups": True
+                    }
+                ]
+            },
+            401: {"description": "Authentication required"},
+            403: {"description": "Admin access required"}
+        },
+        tags=["Events"]
+    ),
+    post=extend_schema(
+        summary="Create New Event",
+        description="Create a new event within the organization. Accessible by organizers and admins. Event categories will be automatically created if they don't exist.",
+        request=EventSerializer,
+        responses={
+            201: {
+                "description": "Event created successfully",
+                "example": {
+                    "id": 1,
+                    "title": "Workshop on Leadership",
+                    "creator": {
+                        "id": 3,
+                        "name": "Jane Organizer",
+                        "profile_image_url": "https://example.com/jane.jpg"
+                    },
+                    "organized_by": "HR Department",
+                    "venue_name": "Conference Room A",
+                    "description": "Interactive leadership workshop for all members.",
+                    "capacity": 50,
+                    "start_date_time": 1735689600000,
+                    "end_date_time": 1735693200000,
+                    "image_url": "",
+                    "is_published": False,
+                    "is_sign_up_allowed": True,
+                    "is_sign_up_approval_required": True,
+                    "categories": ["Workshop", "Professional Development"],
+                    "sign_up_count": 0,
+                    "can_modify": True,
+                    "can_view_sign_ups": True
+                }
+            },
+            400: {
+                "description": "Invalid input data",
+                "example": {
+                    "end_date_time": ["Event end date/time cannot be before start date/time"]
+                }
+            },
+            401: {"description": "Authentication required"},
+            403: {"description": "Organizer or admin access required"}
+        },
+        tags=["Events"]
+    )
+)
 class EventsView(APIView):
     @check_access(Role.ADMIN)
     def get(self, request, requester: User):
+        """
+        Get all events within the organization.
+        
+        Admin-only endpoint that returns comprehensive details about all events
+        in the organization, including sign-up counts, categories, and permissions.
+        """
         same_organization_events = (
             get_events(creator__organization=requester.organization)
             .prefetch_related(
@@ -62,6 +176,13 @@ class EventsView(APIView):
 
     @check_access(Role.ORGANIZER, Role.ADMIN)
     def post(self, request, requester: User):
+        """
+        Create a new event.
+        
+        Creates a new event with the provided details. Event categories specified
+        in the request will be automatically created if they don't exist in the organization.
+        Only organizers and admins can create events.
+        """
         serializer = EventSerializer(data=request.data)
 
         serializer.is_valid(raise_exception=True)
@@ -94,9 +215,54 @@ class EventsView(APIView):
         return Response(data, status=status.HTTP_201_CREATED)
 
 
+@extend_schema_view(
+    get=extend_schema(
+        summary="Get Own Created Events",
+        description="Retrieve all events created by the current user. Accessible by organizers and admins only.",
+        responses={
+            200: {
+                "description": "List of events created by the current user",
+                "example": [
+                    {
+                        "id": 2,
+                        "title": "Team Building Workshop",
+                        "creator": {
+                            "id": 3,
+                            "name": "Current User",
+                            "profile_image_url": "https://example.com/user.jpg"
+                        },
+                        "organized_by": "Management Team",
+                        "venue_name": "Meeting Room B",
+                        "description": "Interactive team building activities and exercises.",
+                        "capacity": 30,
+                        "start_date_time": 1735776000000,
+                        "end_date_time": 1735779600000,
+                        "image_url": "https://example.com/workshop.jpg",
+                        "is_published": True,
+                        "is_sign_up_allowed": True,
+                        "is_sign_up_approval_required": False,
+                        "categories": ["Workshop", "Team Building"],
+                        "sign_up_count": 18,
+                        "can_modify": True,
+                        "can_view_sign_ups": True
+                    }
+                ]
+            },
+            401: {"description": "Authentication required"},
+            403: {"description": "Organizer or admin access required"}
+        },
+        tags=["Events"]
+    )
+)
 class OwnEventsView(APIView):
     @check_access(Role.ORGANIZER, Role.ADMIN)
     def get(self, request, requester: User):
+        """
+        Get all events created by the current user.
+        
+        Returns events where the current user is the creator, along with
+        complete event details including sign-up information and categories.
+        """
         same_creator_events = (
             get_events(creator=requester)
             .prefetch_related(
@@ -114,9 +280,53 @@ class OwnEventsView(APIView):
         return Response(data, status=status.HTTP_200_OK)
 
 
+@extend_schema_view(
+    get=extend_schema(
+        summary="Get Signed Up Events",
+        description="Retrieve all published events that the current user has signed up for. Accessible by all authenticated users.",
+        responses={
+            200: {
+                "description": "List of events the current user has signed up for",
+                "example": [
+                    {
+                        "id": 5,
+                        "title": "Photography Workshop",
+                        "creator": {
+                            "id": 7,
+                            "name": "Photo Club Admin",
+                            "profile_image_url": "https://example.com/admin.jpg"
+                        },
+                        "organized_by": "Photography Club",
+                        "venue_name": "Art Studio",
+                        "description": "Learn basic photography techniques and composition.",
+                        "capacity": 20,
+                        "start_date_time": 1735862400000,
+                        "end_date_time": 1735866000000,
+                        "image_url": "https://example.com/photo-workshop.jpg",
+                        "is_published": True,
+                        "is_sign_up_allowed": True,
+                        "is_sign_up_approval_required": True,
+                        "categories": ["Photography", "Arts"],
+                        "sign_up_count": 15,
+                        "can_modify": False,
+                        "can_view_sign_ups": False
+                    }
+                ]
+            },
+            401: {"description": "Authentication required"}
+        },
+        tags=["Events"]
+    )
+)
 class SignedUpEventsView(APIView):
     @check_access(Role.RESIDENT, Role.ORGANIZER, Role.ADMIN)
     def get(self, request, requester: User):
+        """
+        Get all published events the current user has signed up for.
+        
+        Returns only published events where the user has an active sign-up,
+        regardless of the sign-up status (pending, confirmed, or attended).
+        """
         user_published_event_sign_ups = get_event_sign_ups(
             user=requester, event__is_published=True
         ).select_related("event")
@@ -129,9 +339,54 @@ class SignedUpEventsView(APIView):
         return Response(data, status=status.HTTP_200_OK)
 
 
+@extend_schema_view(
+    get=extend_schema(
+        summary="Get Published Events",
+        description="Retrieve all published events within the organization. Shows events that are publicly available to all users.",
+        responses={
+            200: {
+                "description": "List of all published events in the organization",
+                "example": [
+                    {
+                        "id": 8,
+                        "title": "Community Cleanup Drive",
+                        "creator": {
+                            "id": 4,
+                            "name": "Community Leader",
+                            "profile_image_url": "https://example.com/leader.jpg"
+                        },
+                        "organized_by": "Green Initiative Committee",
+                        "venue_name": "Campus Grounds",
+                        "description": "Join us in keeping our community clean and green.",
+                        "capacity": 200,
+                        "start_date_time": 1735948800000,
+                        "end_date_time": 1735959600000,
+                        "image_url": "https://example.com/cleanup.jpg",
+                        "is_published": True,
+                        "is_sign_up_allowed": True,
+                        "is_sign_up_approval_required": False,
+                        "categories": ["Community Service", "Environment"],
+                        "sign_up_count": 87,
+                        "can_modify": False,
+                        "can_view_sign_ups": False
+                    }
+                ]
+            },
+            401: {"description": "Authentication required"}
+        },
+        tags=["Events"]
+    )
+)
 class PublishedEventsView(APIView):
     @check_access(Role.RESIDENT, Role.ORGANIZER, Role.ADMIN)
     def get(self, request, requester: User):
+        """
+        Get all published events in the organization.
+        
+        Returns events that have been marked as published and are visible
+        to all organization members. Includes complete event details and
+        current sign-up counts.
+        """
         same_organization_published_events = (
             get_events(creator__organization=requester.organization, is_published=True)
             .prefetch_related(
@@ -152,11 +407,152 @@ class PublishedEventsView(APIView):
         return Response(data, status=status.HTTP_200_OK)
 
 
+@extend_schema_view(
+    get=extend_schema(
+        summary="Get Single Event Details",
+        description="Retrieve detailed information about a specific event, including all sign-ups. Access controlled by organization membership and event visibility permissions.",
+        parameters=[
+            OpenApiParameter(
+                name="event_id",
+                description="Unique identifier of the event",
+                required=True,
+                type=int,
+                location=OpenApiParameter.PATH
+            )
+        ],
+        responses={
+            200: {
+                "description": "Detailed event information with sign-ups",
+                "example": {
+                    "event": {
+                        "id": 12,
+                        "title": "Annual Conference 2025",
+                        "creator": {
+                            "id": 8,
+                            "name": "Conference Organizer",
+                            "profile_image_url": "https://example.com/organizer.jpg"
+                        },
+                        "organized_by": "Academic Committee",
+                        "venue_name": "Main Auditorium",
+                        "description": "Annual academic conference with keynote speakers and workshops.",
+                        "capacity": 300,
+                        "start_date_time": 1736035200000,
+                        "end_date_time": 1736049600000,
+                        "image_url": "https://example.com/conference.jpg",
+                        "is_published": True,
+                        "is_sign_up_allowed": True,
+                        "is_sign_up_approval_required": True,
+                        "categories": ["Academic", "Conference"],
+                        "sign_up_count": 156,
+                        "can_modify": False,
+                        "can_view_sign_ups": True
+                    },
+                    "sign_ups": [
+                        {
+                            "id": 45,
+                            "user": {
+                                "id": 23,
+                                "name": "Jane Participant",
+                                "email": "jane@university.edu",
+                                "profile_image_url": "https://example.com/jane-participant.jpg"
+                            },
+                            "status": "CONFIRMED",
+                            "created_at": 1735689600000
+                        }
+                    ]
+                }
+            },
+            401: {"description": "Authentication required"},
+            403: {"description": "Not authorized to view this event"},
+            404: {"description": "Event not found"}
+        },
+        tags=["Events"]
+    ),
+    put=extend_schema(
+        summary="Update Event",
+        description="Update an existing event. Only event creators, organizers, and admins from the same organization can modify events.",
+        parameters=[
+            OpenApiParameter(
+                name="event_id",
+                description="Unique identifier of the event to update",
+                required=True,
+                type=int,
+                location=OpenApiParameter.PATH
+            )
+        ],
+        request=EventSerializer,
+        responses={
+            200: {
+                "description": "Event updated successfully",
+                "example": {
+                    "id": 12,
+                    "title": "Updated Conference Title",
+                    "creator": {
+                        "id": 8,
+                        "name": "Conference Organizer",
+                        "profile_image_url": "https://example.com/organizer.jpg"
+                    },
+                    "organized_by": "Academic Committee",
+                    "venue_name": "Updated Venue",
+                    "description": "Updated conference description with new details.",
+                    "capacity": 250,
+                    "start_date_time": 1736035200000,
+                    "end_date_time": 1736049600000,
+                    "image_url": "https://example.com/updated-image.jpg",
+                    "is_published": True,
+                    "is_sign_up_allowed": True,
+                    "is_sign_up_approval_required": True,
+                    "categories": ["Academic", "Conference", "Updated"],
+                    "sign_up_count": 156,
+                    "can_modify": True,
+                    "can_view_sign_ups": True
+                }
+            },
+            400: {
+                "description": "Invalid input data",
+                "example": {
+                    "end_date_time": ["Event end date/time cannot be before start date/time"]
+                }
+            },
+            401: {"description": "Authentication required"},
+            403: {"description": "Not authorized to modify this event"},
+            404: {"description": "Event not found"}
+        },
+        tags=["Events"]
+    ),
+    delete=extend_schema(
+        summary="Delete Event",
+        description="Delete an existing event. Only event creators, organizers, and admins from the same organization can delete events. Unused event category types will be automatically cleaned up.",
+        parameters=[
+            OpenApiParameter(
+                name="event_id",
+                description="Unique identifier of the event to delete",
+                required=True,
+                type=int,
+                location=OpenApiParameter.PATH
+            )
+        ],
+        responses={
+            204: {"description": "Event deleted successfully"},
+            401: {"description": "Authentication required"},
+            403: {"description": "Not authorized to delete this event"},
+            404: {"description": "Event not found"}
+        },
+        tags=["Events"]
+    )
+)
 class SingleEventView(APIView):
     @check_access(Role.RESIDENT, Role.ORGANIZER, Role.ADMIN)
     @check_requester_event_same_organization
     @check_event_viewer
     def get(self, request, requester: User, event: Event):
+        """
+        Get detailed information about a specific event.
+        
+        Returns comprehensive event details along with all sign-ups if the user
+        has permission to view them. Access is controlled by organization membership
+        and event visibility settings.
+        """
         sign_ups = get_event_sign_ups(event=event).select_related(
             "user__organization", "user__profile_image"
         )
@@ -172,6 +568,13 @@ class SingleEventView(APIView):
     @check_requester_event_same_organization
     @check_event_modifier
     def put(self, request, requester: User, event: Event):
+        """
+        Update an existing event.
+        
+        Updates event details with the provided data. Only users with modification
+        permissions (event creator, organizers, admins) can update events.
+        Event categories will be updated accordingly.
+        """
         serializer = EventSerializer(data=request.data)
 
         serializer.is_valid(raise_exception=True)
@@ -207,6 +610,13 @@ class SingleEventView(APIView):
     @check_requester_event_same_organization
     @check_event_modifier
     def delete(self, request, requester: User, event: Event):
+        """
+        Delete an existing event.
+        
+        Permanently removes the event and all associated data. Also cleans up
+        any unused event category types within the organization. Only users
+        with modification permissions can delete events.
+        """
         event.delete()
         delete_unused_event_category_types(organization=requester.organization)
 

--- a/backend/treeckle/events/views/event.py
+++ b/backend/treeckle/events/views/event.py
@@ -34,17 +34,12 @@ from events.middlewares import (
         responses={
             200: {
                 "description": "List of event category types",
-                "example": [
-                    "Sports",
-                    "Academic",
-                    "Social",
-                    "Workshop"
-                ]
+                "example": ["Sports", "Academic", "Social", "Workshop"],
             },
             401: {"description": "Authentication required"},
-            403: {"description": "Insufficient permissions"}
+            403: {"description": "Insufficient permissions"},
         },
-        tags=["Events"]
+        tags=["Events"],
     )
 )
 class EventCategoryTypesView(APIView):
@@ -52,7 +47,7 @@ class EventCategoryTypesView(APIView):
     def get(self, request, requester: User):
         """
         Get all event category types available in the user's organization.
-        
+
         Returns a list of category type names that can be used when creating or filtering events.
         Only includes category types from the same organization as the requesting user.
         """
@@ -82,7 +77,7 @@ class EventCategoryTypesView(APIView):
                         "creator": {
                             "id": 2,
                             "name": "John Organizer",
-                            "profile_image_url": "https://example.com/image.jpg"
+                            "profile_image_url": "https://example.com/image.jpg",
                         },
                         "organized_by": "Sports Committee",
                         "venue_name": "Sports Complex",
@@ -97,14 +92,14 @@ class EventCategoryTypesView(APIView):
                         "categories": ["Sports", "Recreation"],
                         "sign_up_count": 45,
                         "can_modify": True,
-                        "can_view_sign_ups": True
+                        "can_view_sign_ups": True,
                     }
-                ]
+                ],
             },
             401: {"description": "Authentication required"},
-            403: {"description": "Admin access required"}
+            403: {"description": "Admin access required"},
         },
-        tags=["Events"]
+        tags=["Events"],
     ),
     post=extend_schema(
         summary="Create New Event",
@@ -119,7 +114,7 @@ class EventCategoryTypesView(APIView):
                     "creator": {
                         "id": 3,
                         "name": "Jane Organizer",
-                        "profile_image_url": "https://example.com/jane.jpg"
+                        "profile_image_url": "https://example.com/jane.jpg",
                     },
                     "organized_by": "HR Department",
                     "venue_name": "Conference Room A",
@@ -134,27 +129,29 @@ class EventCategoryTypesView(APIView):
                     "categories": ["Workshop", "Professional Development"],
                     "sign_up_count": 0,
                     "can_modify": True,
-                    "can_view_sign_ups": True
-                }
+                    "can_view_sign_ups": True,
+                },
             },
             400: {
                 "description": "Invalid input data",
                 "example": {
-                    "end_date_time": ["Event end date/time cannot be before start date/time"]
-                }
+                    "end_date_time": [
+                        "Event end date/time cannot be before start date/time"
+                    ]
+                },
             },
             401: {"description": "Authentication required"},
-            403: {"description": "Organizer or admin access required"}
+            403: {"description": "Organizer or admin access required"},
         },
-        tags=["Events"]
-    )
+        tags=["Events"],
+    ),
 )
 class EventsView(APIView):
     @check_access(Role.ADMIN)
     def get(self, request, requester: User):
         """
         Get all events within the organization.
-        
+
         Admin-only endpoint that returns comprehensive details about all events
         in the organization, including sign-up counts, categories, and permissions.
         """
@@ -178,7 +175,7 @@ class EventsView(APIView):
     def post(self, request, requester: User):
         """
         Create a new event.
-        
+
         Creates a new event with the provided details. Event categories specified
         in the request will be automatically created if they don't exist in the organization.
         Only organizers and admins can create events.
@@ -229,7 +226,7 @@ class EventsView(APIView):
                         "creator": {
                             "id": 3,
                             "name": "Current User",
-                            "profile_image_url": "https://example.com/user.jpg"
+                            "profile_image_url": "https://example.com/user.jpg",
                         },
                         "organized_by": "Management Team",
                         "venue_name": "Meeting Room B",
@@ -244,14 +241,14 @@ class EventsView(APIView):
                         "categories": ["Workshop", "Team Building"],
                         "sign_up_count": 18,
                         "can_modify": True,
-                        "can_view_sign_ups": True
+                        "can_view_sign_ups": True,
                     }
-                ]
+                ],
             },
             401: {"description": "Authentication required"},
-            403: {"description": "Organizer or admin access required"}
+            403: {"description": "Organizer or admin access required"},
         },
-        tags=["Events"]
+        tags=["Events"],
     )
 )
 class OwnEventsView(APIView):
@@ -259,7 +256,7 @@ class OwnEventsView(APIView):
     def get(self, request, requester: User):
         """
         Get all events created by the current user.
-        
+
         Returns events where the current user is the creator, along with
         complete event details including sign-up information and categories.
         """
@@ -294,7 +291,7 @@ class OwnEventsView(APIView):
                         "creator": {
                             "id": 7,
                             "name": "Photo Club Admin",
-                            "profile_image_url": "https://example.com/admin.jpg"
+                            "profile_image_url": "https://example.com/admin.jpg",
                         },
                         "organized_by": "Photography Club",
                         "venue_name": "Art Studio",
@@ -309,13 +306,13 @@ class OwnEventsView(APIView):
                         "categories": ["Photography", "Arts"],
                         "sign_up_count": 15,
                         "can_modify": False,
-                        "can_view_sign_ups": False
+                        "can_view_sign_ups": False,
                     }
-                ]
+                ],
             },
-            401: {"description": "Authentication required"}
+            401: {"description": "Authentication required"},
         },
-        tags=["Events"]
+        tags=["Events"],
     )
 )
 class SignedUpEventsView(APIView):
@@ -323,7 +320,7 @@ class SignedUpEventsView(APIView):
     def get(self, request, requester: User):
         """
         Get all published events the current user has signed up for.
-        
+
         Returns only published events where the user has an active sign-up,
         regardless of the sign-up status (pending, confirmed, or attended).
         """
@@ -353,7 +350,7 @@ class SignedUpEventsView(APIView):
                         "creator": {
                             "id": 4,
                             "name": "Community Leader",
-                            "profile_image_url": "https://example.com/leader.jpg"
+                            "profile_image_url": "https://example.com/leader.jpg",
                         },
                         "organized_by": "Green Initiative Committee",
                         "venue_name": "Campus Grounds",
@@ -368,13 +365,13 @@ class SignedUpEventsView(APIView):
                         "categories": ["Community Service", "Environment"],
                         "sign_up_count": 87,
                         "can_modify": False,
-                        "can_view_sign_ups": False
+                        "can_view_sign_ups": False,
                     }
-                ]
+                ],
             },
-            401: {"description": "Authentication required"}
+            401: {"description": "Authentication required"},
         },
-        tags=["Events"]
+        tags=["Events"],
     )
 )
 class PublishedEventsView(APIView):
@@ -382,7 +379,7 @@ class PublishedEventsView(APIView):
     def get(self, request, requester: User):
         """
         Get all published events in the organization.
-        
+
         Returns events that have been marked as published and are visible
         to all organization members. Includes complete event details and
         current sign-up counts.
@@ -417,7 +414,7 @@ class PublishedEventsView(APIView):
                 description="Unique identifier of the event",
                 required=True,
                 type=int,
-                location=OpenApiParameter.PATH
+                location=OpenApiParameter.PATH,
             )
         ],
         responses={
@@ -430,7 +427,7 @@ class PublishedEventsView(APIView):
                         "creator": {
                             "id": 8,
                             "name": "Conference Organizer",
-                            "profile_image_url": "https://example.com/organizer.jpg"
+                            "profile_image_url": "https://example.com/organizer.jpg",
                         },
                         "organized_by": "Academic Committee",
                         "venue_name": "Main Auditorium",
@@ -445,7 +442,7 @@ class PublishedEventsView(APIView):
                         "categories": ["Academic", "Conference"],
                         "sign_up_count": 156,
                         "can_modify": False,
-                        "can_view_sign_ups": True
+                        "can_view_sign_ups": True,
                     },
                     "sign_ups": [
                         {
@@ -454,19 +451,19 @@ class PublishedEventsView(APIView):
                                 "id": 23,
                                 "name": "Jane Participant",
                                 "email": "jane@university.edu",
-                                "profile_image_url": "https://example.com/jane-participant.jpg"
+                                "profile_image_url": "https://example.com/jane-participant.jpg",
                             },
                             "status": "CONFIRMED",
-                            "created_at": 1735689600000
+                            "created_at": 1735689600000,
                         }
-                    ]
-                }
+                    ],
+                },
             },
             401: {"description": "Authentication required"},
             403: {"description": "Not authorized to view this event"},
-            404: {"description": "Event not found"}
+            404: {"description": "Event not found"},
         },
-        tags=["Events"]
+        tags=["Events"],
     ),
     put=extend_schema(
         summary="Update Event",
@@ -477,7 +474,7 @@ class PublishedEventsView(APIView):
                 description="Unique identifier of the event to update",
                 required=True,
                 type=int,
-                location=OpenApiParameter.PATH
+                location=OpenApiParameter.PATH,
             )
         ],
         request=EventSerializer,
@@ -490,7 +487,7 @@ class PublishedEventsView(APIView):
                     "creator": {
                         "id": 8,
                         "name": "Conference Organizer",
-                        "profile_image_url": "https://example.com/organizer.jpg"
+                        "profile_image_url": "https://example.com/organizer.jpg",
                     },
                     "organized_by": "Academic Committee",
                     "venue_name": "Updated Venue",
@@ -505,20 +502,22 @@ class PublishedEventsView(APIView):
                     "categories": ["Academic", "Conference", "Updated"],
                     "sign_up_count": 156,
                     "can_modify": True,
-                    "can_view_sign_ups": True
-                }
+                    "can_view_sign_ups": True,
+                },
             },
             400: {
                 "description": "Invalid input data",
                 "example": {
-                    "end_date_time": ["Event end date/time cannot be before start date/time"]
-                }
+                    "end_date_time": [
+                        "Event end date/time cannot be before start date/time"
+                    ]
+                },
             },
             401: {"description": "Authentication required"},
             403: {"description": "Not authorized to modify this event"},
-            404: {"description": "Event not found"}
+            404: {"description": "Event not found"},
         },
-        tags=["Events"]
+        tags=["Events"],
     ),
     delete=extend_schema(
         summary="Delete Event",
@@ -529,17 +528,17 @@ class PublishedEventsView(APIView):
                 description="Unique identifier of the event to delete",
                 required=True,
                 type=int,
-                location=OpenApiParameter.PATH
+                location=OpenApiParameter.PATH,
             )
         ],
         responses={
             204: {"description": "Event deleted successfully"},
             401: {"description": "Authentication required"},
             403: {"description": "Not authorized to delete this event"},
-            404: {"description": "Event not found"}
+            404: {"description": "Event not found"},
         },
-        tags=["Events"]
-    )
+        tags=["Events"],
+    ),
 )
 class SingleEventView(APIView):
     @check_access(Role.RESIDENT, Role.ORGANIZER, Role.ADMIN)
@@ -548,7 +547,7 @@ class SingleEventView(APIView):
     def get(self, request, requester: User, event: Event):
         """
         Get detailed information about a specific event.
-        
+
         Returns comprehensive event details along with all sign-ups if the user
         has permission to view them. Access is controlled by organization membership
         and event visibility settings.
@@ -570,7 +569,7 @@ class SingleEventView(APIView):
     def put(self, request, requester: User, event: Event):
         """
         Update an existing event.
-        
+
         Updates event details with the provided data. Only users with modification
         permissions (event creator, organizers, admins) can update events.
         Event categories will be updated accordingly.
@@ -612,7 +611,7 @@ class SingleEventView(APIView):
     def delete(self, request, requester: User, event: Event):
         """
         Delete an existing event.
-        
+
         Permanently removes the event and all associated data. Also cleans up
         any unused event category types within the organization. Only users
         with modification permissions can delete events.

--- a/backend/treeckle/events/views/sign_up.py
+++ b/backend/treeckle/events/views/sign_up.py
@@ -82,7 +82,9 @@ from events.serializers import PatchEventSignUpSerializer
                     "created_at": 1735689600000,
                 },
             },
-            400: {"description": "Not signed up for this event or invalid status transition"},
+            400: {
+                "description": "Not signed up for this event or invalid status transition"
+            },
             401: {"description": "Authentication required"},
             403: {"description": "Not authorized to mark attendance for this event"},
             404: {"description": "Event not found"},

--- a/backend/treeckle/events/views/sign_up.py
+++ b/backend/treeckle/events/views/sign_up.py
@@ -1,6 +1,7 @@
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
+from drf_spectacular.utils import extend_schema, extend_schema_view, OpenApiParameter
 
 from users.permission_middlewares import check_access
 from users.models import Role, User
@@ -19,10 +20,108 @@ from events.models import Event
 from events.serializers import PatchEventSignUpSerializer
 
 
+@extend_schema_view(
+    post=extend_schema(
+        summary="Sign Up for Event",
+        description="Sign up the current user for a specific event. The user must be from the same organization as the event.",
+        parameters=[
+            OpenApiParameter(
+                name="event_id",
+                description="Unique identifier of the event to sign up for",
+                required=True,
+                type=int,
+                location=OpenApiParameter.PATH,
+            )
+        ],
+        responses={
+            201: {
+                "description": "Successfully signed up for the event",
+                "example": {
+                    "id": 67,
+                    "user": {
+                        "id": 15,
+                        "name": "John Participant",
+                        "email": "john@university.edu",
+                        "profile_image_url": "https://example.com/john.jpg",
+                    },
+                    "status": "PENDING",
+                    "created_at": 1735689600000,
+                },
+            },
+            400: {"description": "Already signed up for this event or event is full"},
+            401: {"description": "Authentication required"},
+            403: {"description": "Not authorized to sign up for this event"},
+            404: {"description": "Event not found"},
+        },
+        tags=["Event Sign-ups"],
+    ),
+    patch=extend_schema(
+        summary="Mark Event Attendance",
+        description="Mark the current user's attendance for an event they are signed up for. Updates sign-up status to 'ATTENDED'.",
+        parameters=[
+            OpenApiParameter(
+                name="event_id",
+                description="Unique identifier of the event to mark attendance for",
+                required=True,
+                type=int,
+                location=OpenApiParameter.PATH,
+            )
+        ],
+        responses={
+            200: {
+                "description": "Attendance marked successfully",
+                "example": {
+                    "id": 67,
+                    "user": {
+                        "id": 15,
+                        "name": "John Participant",
+                        "email": "john@university.edu",
+                        "profile_image_url": "https://example.com/john.jpg",
+                    },
+                    "status": "ATTENDED",
+                    "created_at": 1735689600000,
+                },
+            },
+            400: {"description": "Not signed up for this event or invalid status transition"},
+            401: {"description": "Authentication required"},
+            403: {"description": "Not authorized to mark attendance for this event"},
+            404: {"description": "Event not found"},
+        },
+        tags=["Event Sign-ups"],
+    ),
+    delete=extend_schema(
+        summary="Cancel Event Sign-up",
+        description="Cancel the current user's sign-up for a specific event. Removes the sign-up record completely.",
+        parameters=[
+            OpenApiParameter(
+                name="event_id",
+                description="Unique identifier of the event to cancel sign-up for",
+                required=True,
+                type=int,
+                location=OpenApiParameter.PATH,
+            )
+        ],
+        responses={
+            204: {"description": "Sign-up cancelled successfully"},
+            400: {"description": "Not signed up for this event"},
+            401: {"description": "Authentication required"},
+            403: {"description": "Not authorized to cancel sign-up for this event"},
+            404: {"description": "Event not found"},
+        },
+        tags=["Event Sign-ups"],
+    ),
+)
 class SelfSignUpView(APIView):
     @check_access(Role.RESIDENT, Role.ORGANIZER, Role.ADMIN)
     @check_requester_event_same_organization
     def post(self, request, requester: User, event: Event):
+        """
+        Sign up the current user for an event.
+
+        Creates a new sign-up record for the current user and the specified event.
+        The sign-up status will be 'PENDING' initially, and may require approval
+        depending on the event settings.
+        """
         new_event_sign_up = create_event_sign_up(event=event, user=requester)
 
         data = event_sign_up_to_json(new_event_sign_up)
@@ -32,6 +131,12 @@ class SelfSignUpView(APIView):
     @check_access(Role.RESIDENT, Role.ORGANIZER, Role.ADMIN)
     @check_requester_event_same_organization
     def patch(self, request, requester: User, event: Event):
+        """
+        Mark attendance for the current user's event sign-up.
+
+        Updates the sign-up status to 'ATTENDED' for the current user.
+        The user must already be signed up for the event.
+        """
         attended_event_sign_up = attend_event_sign_up(event=event, user=requester)
 
         data = event_sign_up_to_json(attended_event_sign_up)
@@ -41,16 +146,84 @@ class SelfSignUpView(APIView):
     @check_access(Role.RESIDENT, Role.ORGANIZER, Role.ADMIN)
     @check_requester_event_same_organization
     def delete(self, request, requester: User, event: Event):
+        """
+        Cancel the current user's sign-up for an event.
+
+        Completely removes the sign-up record for the current user and the specified event.
+        This action cannot be undone, and the user would need to sign up again if desired.
+        """
         delete_event_sign_up(event=event, user=requester)
 
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 
+@extend_schema_view(
+    patch=extend_schema(
+        summary="Manage Event Sign-ups",
+        description="Batch update sign-up statuses for an event. Only event organizers and admins can manage sign-ups. Supports confirming, rejecting, or marking attendance for multiple users.",
+        parameters=[
+            OpenApiParameter(
+                name="event_id",
+                description="Unique identifier of the event to manage sign-ups for",
+                required=True,
+                type=int,
+                location=OpenApiParameter.PATH,
+            )
+        ],
+        request=PatchEventSignUpSerializer,
+        responses={
+            200: {
+                "description": "Sign-ups updated successfully",
+                "example": [
+                    {
+                        "id": 23,
+                        "user": {
+                            "id": 45,
+                            "name": "Alice Student",
+                            "email": "alice@university.edu",
+                            "profile_image_url": "https://example.com/alice.jpg",
+                        },
+                        "status": "CONFIRMED",
+                        "created_at": 1735689600000,
+                    },
+                    {
+                        "id": 24,
+                        "user": {
+                            "id": 46,
+                            "name": "Bob Student",
+                            "email": "bob@university.edu",
+                            "profile_image_url": "https://example.com/bob.jpg",
+                        },
+                        "status": "ATTENDED",
+                        "created_at": 1735693200000,
+                    },
+                ],
+            },
+            400: {
+                "description": "Invalid action or user not found",
+                "example": {
+                    "actions": ["Invalid action or user not found for some entries"]
+                },
+            },
+            401: {"description": "Authentication required"},
+            403: {"description": "Not authorized to manage sign-ups for this event"},
+            404: {"description": "Event not found"},
+        },
+        tags=["Event Sign-ups"],
+    )
+)
 class SignUpView(APIView):
     @check_access(Role.ORGANIZER, Role.ADMIN)
     @check_requester_event_same_organization
     @check_event_modifier
     def patch(self, request, requester: User, event: Event):
+        """
+        Batch update event sign-up statuses.
+
+        Allows event organizers and admins to perform bulk actions on event sign-ups,
+        such as confirming pending sign-ups, rejecting applications, or marking attendance.
+        Each action specifies a user ID and the desired action (CONFIRM, REJECT, ATTEND).
+        """
         serializer = PatchEventSignUpSerializer(data=request.data)
 
         serializer.is_valid(raise_exception=True)

--- a/backend/treeckle/events/views/subscription.py
+++ b/backend/treeckle/events/views/subscription.py
@@ -30,21 +30,17 @@ from events.logic.subscription import (
             200: {
                 "description": "User's event category subscription information",
                 "example": {
-                    "subscribed_categories": [
-                        "Sports",
-                        "Academic",
-                        "Workshop"
-                    ],
+                    "subscribed_categories": ["Sports", "Academic", "Workshop"],
                     "non_subscribed_categories": [
                         "Social",
                         "Arts",
-                        "Community Service"
-                    ]
-                }
+                        "Community Service",
+                    ],
+                },
             },
-            401: {"description": "Authentication required"}
+            401: {"description": "Authentication required"},
         },
-        tags=["Event Subscriptions"]
+        tags=["Event Subscriptions"],
     ),
     patch=extend_schema(
         summary="Update Event Category Subscriptions",
@@ -54,35 +50,25 @@ from events.logic.subscription import (
             200: {
                 "description": "Subscriptions updated successfully",
                 "example": {
-                    "subscribed_categories": [
-                        "Sports",
-                        "Academic",
-                        "Workshop",
-                        "Arts"
-                    ],
-                    "non_subscribed_categories": [
-                        "Social",
-                        "Community Service"
-                    ]
-                }
+                    "subscribed_categories": ["Sports", "Academic", "Workshop", "Arts"],
+                    "non_subscribed_categories": ["Social", "Community Service"],
+                },
             },
             400: {
                 "description": "Invalid subscription data",
-                "example": {
-                    "actions": ["Invalid action or category not found"]
-                }
+                "example": {"actions": ["Invalid action or category not found"]},
             },
-            401: {"description": "Authentication required"}
+            401: {"description": "Authentication required"},
         },
-        tags=["Event Subscriptions"]
-    )
+        tags=["Event Subscriptions"],
+    ),
 )
 class OwnEventCategoryTypeSubscriptionsView(APIView):
     @check_access(Role.RESIDENT, Role.ORGANIZER, Role.ADMIN)
     def get(self, request, requester: User):
         """
         Get the current user's event category subscriptions.
-        
+
         Returns two lists: categories the user is subscribed to and categories
         available for subscription within their organization.
         """
@@ -102,7 +88,7 @@ class OwnEventCategoryTypeSubscriptionsView(APIView):
     def patch(self, request, requester: User):
         """
         Update the current user's event category subscriptions.
-        
+
         Processes a list of subscription actions, allowing the user to subscribe
         to new categories or unsubscribe from existing ones. Each action specifies
         a category name and the desired action (SUBSCRIBE or UNSUBSCRIBE).
@@ -142,7 +128,7 @@ class OwnEventCategoryTypeSubscriptionsView(APIView):
                         "creator": {
                             "id": 12,
                             "name": "Sports Coordinator",
-                            "profile_image_url": "https://example.com/coordinator.jpg"
+                            "profile_image_url": "https://example.com/coordinator.jpg",
                         },
                         "organized_by": "Sports Club",
                         "venue_name": "Basketball Court",
@@ -157,7 +143,7 @@ class OwnEventCategoryTypeSubscriptionsView(APIView):
                         "categories": ["Sports"],
                         "sign_up_count": 24,
                         "can_modify": False,
-                        "can_view_sign_ups": False
+                        "can_view_sign_ups": False,
                     },
                     {
                         "id": 16,
@@ -165,7 +151,7 @@ class OwnEventCategoryTypeSubscriptionsView(APIView):
                         "creator": {
                             "id": 8,
                             "name": "CS Professor",
-                            "profile_image_url": "https://example.com/professor.jpg"
+                            "profile_image_url": "https://example.com/professor.jpg",
                         },
                         "organized_by": "Computer Science Department",
                         "venue_name": "Lab 101",
@@ -180,13 +166,13 @@ class OwnEventCategoryTypeSubscriptionsView(APIView):
                         "categories": ["Academic", "Workshop"],
                         "sign_up_count": 18,
                         "can_modify": False,
-                        "can_view_sign_ups": False
-                    }
-                ]
+                        "can_view_sign_ups": False,
+                    },
+                ],
             },
-            401: {"description": "Authentication required"}
+            401: {"description": "Authentication required"},
         },
-        tags=["Event Subscriptions"]
+        tags=["Event Subscriptions"],
     )
 )
 class SubscribedEventsView(APIView):
@@ -194,7 +180,7 @@ class SubscribedEventsView(APIView):
     def get(self, request, requester: User):
         """
         Get all published events from subscribed categories.
-        
+
         Returns events that are published and belong to categories the user
         has subscribed to. This helps users discover relevant events based
         on their interests without having to browse all available events.

--- a/backend/treeckle/events/views/subscription.py
+++ b/backend/treeckle/events/views/subscription.py
@@ -3,6 +3,7 @@ from django.db.models import Prefetch
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
+from drf_spectacular.utils import extend_schema, extend_schema_view
 
 from treeckle.common.constants import SUBSCRIBED_CATEGORIES, NON_SUBSCRIBED_CATEGORIES
 from users.permission_middlewares import check_access
@@ -21,9 +22,70 @@ from events.logic.subscription import (
 )
 
 
+@extend_schema_view(
+    get=extend_schema(
+        summary="Get Event Category Subscriptions",
+        description="Retrieve the current user's event category subscriptions. Shows which categories the user is subscribed to and which are available for subscription.",
+        responses={
+            200: {
+                "description": "User's event category subscription information",
+                "example": {
+                    "subscribed_categories": [
+                        "Sports",
+                        "Academic",
+                        "Workshop"
+                    ],
+                    "non_subscribed_categories": [
+                        "Social",
+                        "Arts",
+                        "Community Service"
+                    ]
+                }
+            },
+            401: {"description": "Authentication required"}
+        },
+        tags=["Event Subscriptions"]
+    ),
+    patch=extend_schema(
+        summary="Update Event Category Subscriptions",
+        description="Update the current user's event category subscriptions. Allows subscribing to or unsubscribing from multiple categories in a single request.",
+        request=PatchEventCategoryTypeSubscriptionSerializer,
+        responses={
+            200: {
+                "description": "Subscriptions updated successfully",
+                "example": {
+                    "subscribed_categories": [
+                        "Sports",
+                        "Academic",
+                        "Workshop",
+                        "Arts"
+                    ],
+                    "non_subscribed_categories": [
+                        "Social",
+                        "Community Service"
+                    ]
+                }
+            },
+            400: {
+                "description": "Invalid subscription data",
+                "example": {
+                    "actions": ["Invalid action or category not found"]
+                }
+            },
+            401: {"description": "Authentication required"}
+        },
+        tags=["Event Subscriptions"]
+    )
+)
 class OwnEventCategoryTypeSubscriptionsView(APIView):
     @check_access(Role.RESIDENT, Role.ORGANIZER, Role.ADMIN)
     def get(self, request, requester: User):
+        """
+        Get the current user's event category subscriptions.
+        
+        Returns two lists: categories the user is subscribed to and categories
+        available for subscription within their organization.
+        """
         (
             subscribed_categories,
             non_subscribed_categories,
@@ -38,6 +100,13 @@ class OwnEventCategoryTypeSubscriptionsView(APIView):
 
     @check_access(Role.RESIDENT, Role.ORGANIZER, Role.ADMIN)
     def patch(self, request, requester: User):
+        """
+        Update the current user's event category subscriptions.
+        
+        Processes a list of subscription actions, allowing the user to subscribe
+        to new categories or unsubscribe from existing ones. Each action specifies
+        a category name and the desired action (SUBSCRIBE or UNSUBSCRIBE).
+        """
         serializer = PatchEventCategoryTypeSubscriptionSerializer(data=request.data)
 
         serializer.is_valid(raise_exception=True)
@@ -59,9 +128,77 @@ class OwnEventCategoryTypeSubscriptionsView(APIView):
         return Response(data, status=status.HTTP_200_OK)
 
 
+@extend_schema_view(
+    get=extend_schema(
+        summary="Get Subscribed Events",
+        description="Retrieve all published events that match the current user's category subscriptions. Shows events from categories the user has subscribed to receive notifications about.",
+        responses={
+            200: {
+                "description": "List of events from subscribed categories",
+                "example": [
+                    {
+                        "id": 15,
+                        "title": "Weekly Basketball Tournament",
+                        "creator": {
+                            "id": 12,
+                            "name": "Sports Coordinator",
+                            "profile_image_url": "https://example.com/coordinator.jpg"
+                        },
+                        "organized_by": "Sports Club",
+                        "venue_name": "Basketball Court",
+                        "description": "Weekly basketball tournament for all skill levels.",
+                        "capacity": 32,
+                        "start_date_time": 1736121600000,
+                        "end_date_time": 1736128800000,
+                        "image_url": "https://example.com/basketball.jpg",
+                        "is_published": True,
+                        "is_sign_up_allowed": True,
+                        "is_sign_up_approval_required": False,
+                        "categories": ["Sports"],
+                        "sign_up_count": 24,
+                        "can_modify": False,
+                        "can_view_sign_ups": False
+                    },
+                    {
+                        "id": 16,
+                        "title": "Advanced Programming Workshop",
+                        "creator": {
+                            "id": 8,
+                            "name": "CS Professor",
+                            "profile_image_url": "https://example.com/professor.jpg"
+                        },
+                        "organized_by": "Computer Science Department",
+                        "venue_name": "Lab 101",
+                        "description": "Deep dive into advanced programming concepts and techniques.",
+                        "capacity": 25,
+                        "start_date_time": 1736208000000,
+                        "end_date_time": 1736218800000,
+                        "image_url": "https://example.com/programming.jpg",
+                        "is_published": True,
+                        "is_sign_up_allowed": True,
+                        "is_sign_up_approval_required": True,
+                        "categories": ["Academic", "Workshop"],
+                        "sign_up_count": 18,
+                        "can_modify": False,
+                        "can_view_sign_ups": False
+                    }
+                ]
+            },
+            401: {"description": "Authentication required"}
+        },
+        tags=["Event Subscriptions"]
+    )
+)
 class SubscribedEventsView(APIView):
     @check_access(Role.RESIDENT, Role.ORGANIZER, Role.ADMIN)
     def get(self, request, requester: User):
+        """
+        Get all published events from subscribed categories.
+        
+        Returns events that are published and belong to categories the user
+        has subscribed to. This helps users discover relevant events based
+        on their interests without having to browse all available events.
+        """
         user_subscriptions = get_event_category_type_subscriptions(
             user=requester
         ).select_related("category")

--- a/backend/treeckle/events/views/subscription.py
+++ b/backend/treeckle/events/views/subscription.py
@@ -1,4 +1,3 @@
-
 from django.db.models import Prefetch
 
 from rest_framework import status

--- a/backend/treeckle/nusmods/urls.py
+++ b/backend/treeckle/nusmods/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path
-from . import views 
+from . import views
 
 urlpatterns = [
     path("academic-weeks/", views.get_academic_weeks, name="academic-weeks"),

--- a/backend/treeckle/nusmods/views.py
+++ b/backend/treeckle/nusmods/views.py
@@ -12,11 +12,11 @@ import json
 def get_week_dates(sem_start_date, filtered_data):
     """
     Calculate week dates for a semester based on start date and timetable data.
-    
+
     Args:
         sem_start_date: The Monday of the first week of the semester
         filtered_data: List of timetable entries with week information
-        
+
     Returns:
         List of week objects with week number, start date, and end date
     """
@@ -68,24 +68,24 @@ def get_week_dates(sem_start_date, filtered_data):
                                 {
                                     "week": 1,
                                     "startDate": "05 Aug 2024",
-                                    "endDate": "09 Aug 2024"
+                                    "endDate": "09 Aug 2024",
                                 },
                                 {
                                     "week": 2,
                                     "startDate": "12 Aug 2024",
-                                    "endDate": "16 Aug 2024"
+                                    "endDate": "16 Aug 2024",
                                 },
                                 {
                                     "week": 3,
                                     "startDate": "19 Aug 2024",
-                                    "endDate": "23 Aug 2024"
+                                    "endDate": "23 Aug 2024",
                                 },
                                 {
                                     "week": 13,
                                     "startDate": "25 Nov 2024",
-                                    "endDate": "29 Nov 2024"
-                                }
-                            ]
+                                    "endDate": "29 Nov 2024",
+                                },
+                            ],
                         },
                         {
                             "semester": 2,
@@ -93,18 +93,18 @@ def get_week_dates(sem_start_date, filtered_data):
                                 {
                                     "week": 1,
                                     "startDate": "13 Jan 2025",
-                                    "endDate": "17 Jan 2025"
+                                    "endDate": "17 Jan 2025",
                                 },
                                 {
                                     "week": 2,
                                     "startDate": "20 Jan 2025",
-                                    "endDate": "24 Jan 2025"
-                                }
-                            ]
-                        }
+                                    "endDate": "24 Jan 2025",
+                                },
+                            ],
+                        },
                     ]
                 }
-            ]
+            ],
         ),
         500: OpenApiResponse(
             description="Server error - Failed to fetch data or process request",
@@ -118,12 +118,12 @@ def get_week_dates(sem_start_date, filtered_data):
                     "value": {
                         "error": "An unexpected error occurred: Invalid date format"
                     }
-                }
-            ]
-        )
+                },
+            ],
+        ),
     },
     tags=["Academic Calendar"],
-    auth=[]  # No authentication required
+    auth=[],  # No authentication required
 )
 @api_view(["GET"])
 @permission_classes([AllowAny])
@@ -131,14 +131,14 @@ def get_week_dates(sem_start_date, filtered_data):
 def get_academic_weeks(request):
     """
     Get academic week dates for all semesters.
-    
+
     Fetches module data from the NUSMods API to determine semester structures
     and calculates the date ranges for each academic week. Accounts for recess
     weeks and provides formatted date ranges for frontend calendar integration.
-    
+
     The function uses a reference module (CS1010S) to extract semester timing
     information and maps this to actual calendar dates for academic year 2024-2025.
-    
+
     Returns:
         Response: List of semesters with their respective week date ranges
     """

--- a/backend/treeckle/nusmods/views.py
+++ b/backend/treeckle/nusmods/views.py
@@ -2,6 +2,7 @@ from rest_framework.decorators import api_view, renderer_classes, permission_cla
 from rest_framework.response import Response
 from rest_framework.permissions import AllowAny
 from djangorestframework_camel_case.render import CamelCaseJSONRenderer
+from drf_spectacular.utils import extend_schema, OpenApiResponse
 
 import requests
 import datetime
@@ -9,6 +10,16 @@ import json
 
 
 def get_week_dates(sem_start_date, filtered_data):
+    """
+    Calculate week dates for a semester based on start date and timetable data.
+    
+    Args:
+        sem_start_date: The Monday of the first week of the semester
+        filtered_data: List of timetable entries with week information
+        
+    Returns:
+        List of week objects with week number, start date, and end date
+    """
     days_added = {"Monday": 0, "Tuesday": 1, "Wednesday": 2, "Thursday": 3, "Friday": 4}
     week_dates = []
     seen_weeks = set()
@@ -42,10 +53,95 @@ def get_week_dates(sem_start_date, filtered_data):
     return sorted(week_dates, key=lambda x: x["week"])
 
 
+@extend_schema(
+    summary="Get Academic Week Dates",
+    description="Retrieve academic week dates for all semesters based on NUS academic calendar. Fetches data from NUSMods API to determine semester start dates and calculate weekly date ranges, accounting for recess weeks.",
+    responses={
+        200: OpenApiResponse(
+            description="Academic week dates for all semesters",
+            examples=[
+                {
+                    "value": [
+                        {
+                            "semester": 1,
+                            "weeks": [
+                                {
+                                    "week": 1,
+                                    "startDate": "05 Aug 2024",
+                                    "endDate": "09 Aug 2024"
+                                },
+                                {
+                                    "week": 2,
+                                    "startDate": "12 Aug 2024",
+                                    "endDate": "16 Aug 2024"
+                                },
+                                {
+                                    "week": 3,
+                                    "startDate": "19 Aug 2024",
+                                    "endDate": "23 Aug 2024"
+                                },
+                                {
+                                    "week": 13,
+                                    "startDate": "25 Nov 2024",
+                                    "endDate": "29 Nov 2024"
+                                }
+                            ]
+                        },
+                        {
+                            "semester": 2,
+                            "weeks": [
+                                {
+                                    "week": 1,
+                                    "startDate": "13 Jan 2025",
+                                    "endDate": "17 Jan 2025"
+                                },
+                                {
+                                    "week": 2,
+                                    "startDate": "20 Jan 2025",
+                                    "endDate": "24 Jan 2025"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        ),
+        500: OpenApiResponse(
+            description="Server error - Failed to fetch data or process request",
+            examples=[
+                {
+                    "value": {
+                        "error": "Failed to fetch data from NUSMods API: Connection timeout"
+                    }
+                },
+                {
+                    "value": {
+                        "error": "An unexpected error occurred: Invalid date format"
+                    }
+                }
+            ]
+        )
+    },
+    tags=["Academic Calendar"],
+    auth=[]  # No authentication required
+)
 @api_view(["GET"])
 @permission_classes([AllowAny])
 @renderer_classes([CamelCaseJSONRenderer])
 def get_academic_weeks(request):
+    """
+    Get academic week dates for all semesters.
+    
+    Fetches module data from the NUSMods API to determine semester structures
+    and calculates the date ranges for each academic week. Accounts for recess
+    weeks and provides formatted date ranges for frontend calendar integration.
+    
+    The function uses a reference module (CS1010S) to extract semester timing
+    information and maps this to actual calendar dates for academic year 2024-2025.
+    
+    Returns:
+        Response: List of semesters with their respective week date ranges
+    """
     try:
         result = []
         reference_mod = "CS1010S"

--- a/backend/treeckle/nusmods/views.py
+++ b/backend/treeckle/nusmods/views.py
@@ -1,20 +1,21 @@
 from rest_framework.decorators import api_view, renderer_classes, permission_classes
 from rest_framework.response import Response
 from rest_framework.permissions import AllowAny
-from djangorestframework_camel_case.render import CamelCaseJSONRenderer  
+from djangorestframework_camel_case.render import CamelCaseJSONRenderer
 
 import requests
 import datetime
 import json
 
+
 def get_week_dates(sem_start_date, filtered_data):
-    days_added = {'Monday': 0, 'Tuesday': 1, 'Wednesday': 2, 'Thursday': 3, 'Friday': 4}
+    days_added = {"Monday": 0, "Tuesday": 1, "Wednesday": 2, "Thursday": 3, "Friday": 4}
     week_dates = []
     seen_weeks = set()
 
     for data in filtered_data:
-        day = data['day']
-        weeks = data['weeks']
+        day = data["day"]
+        weeks = data["weeks"]
 
         for week in weeks:
             try:
@@ -22,32 +23,37 @@ def get_week_dates(sem_start_date, filtered_data):
             except ValueError:
                 print(f"Skipping invalid week value: {week}")
                 continue
-                
+
             # Add a week after week 6 to account for recess week
             adjusted_week = week - 1 if week < 6 else week
             monday_date = sem_start_date + datetime.timedelta(weeks=adjusted_week)
-            
+
             if week not in seen_weeks:
                 seen_weeks.add(week)
                 friday_date = monday_date + datetime.timedelta(days=4)
-                week_dates.append({
-                    "week": week,
-                    "startDate": monday_date.strftime("%d %b %Y"),  
-                    "endDate": friday_date.strftime("%d %b %Y")     
-                })
-    
-    return sorted(week_dates, key=lambda x: x['week'])
+                week_dates.append(
+                    {
+                        "week": week,
+                        "startDate": monday_date.strftime("%d %b %Y"),
+                        "endDate": friday_date.strftime("%d %b %Y"),
+                    }
+                )
 
-@api_view(['GET'])
+    return sorted(week_dates, key=lambda x: x["week"])
+
+
+@api_view(["GET"])
 @permission_classes([AllowAny])
-@renderer_classes([CamelCaseJSONRenderer])  
+@renderer_classes([CamelCaseJSONRenderer])
 def get_academic_weeks(request):
     try:
         result = []
-        reference_mod = 'CS1010S'
-        
+        reference_mod = "CS1010S"
+
         # Fetch module data from NUSMods API
-        response = requests.get(f"https://api.nusmods.com/v2/2024-2025/modules/{reference_mod}.json")
+        response = requests.get(
+            f"https://api.nusmods.com/v2/2024-2025/modules/{reference_mod}.json"
+        )
         response.raise_for_status()  # Raise exception for bad status codes
         module_data = response.json()
 
@@ -55,42 +61,37 @@ def get_academic_weeks(request):
         sem_start_dates = {
             1: datetime.date(2024, 8, 5),
             2: datetime.date(2025, 1, 13),
-            3: datetime.date(2025, 5, 12)
+            3: datetime.date(2025, 5, 12),
         }
 
         for semester in module_data.get("semesterData", []):
             timetable = semester.get("timetable", [])
             if not timetable:
                 continue
-                
+
             filtered_data = [
                 {
-                    'semester': semester['semester'],
-                    'weeks': entry['weeks'],
-                    'day': entry['day']
+                    "semester": semester["semester"],
+                    "weeks": entry["weeks"],
+                    "day": entry["day"],
                 }
                 for entry in timetable
             ]
 
             if filtered_data:
-                sem_num = filtered_data[0]['semester']
+                sem_num = filtered_data[0]["semester"]
                 week_dates = get_week_dates(sem_start_dates[sem_num], filtered_data)
-                
+
                 if week_dates:
-                    result.append({
-                        "semester": sem_num,
-                        "weeks": week_dates
-                    })
+                    result.append({"semester": sem_num, "weeks": week_dates})
 
         return Response(result)
 
     except requests.RequestException as e:
         return Response(
-            {"error": f"Failed to fetch data from NUSMods API: {str(e)}"},
-            status=500
+            {"error": f"Failed to fetch data from NUSMods API: {str(e)}"}, status=500
         )
     except Exception as e:
         return Response(
-            {"error": f"An unexpected error occurred: {str(e)}"},
-            status=500
+            {"error": f"An unexpected error occurred: {str(e)}"}, status=500
         )

--- a/backend/treeckle/organizations/tests.py
+++ b/backend/treeckle/organizations/tests.py
@@ -1,2 +1,1 @@
-
 # Create your tests here.

--- a/backend/treeckle/treeckle/rest_api_urls.py
+++ b/backend/treeckle/treeckle/rest_api_urls.py
@@ -1,15 +1,21 @@
 from django.urls import include, path
-from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView, SpectacularRedocView
+from drf_spectacular.views import (
+    SpectacularAPIView,
+    SpectacularSwaggerView,
+    SpectacularRedocView,
+)
 
 urlpatterns = [
-    path('schema/', SpectacularAPIView.as_view(), name='schema'),
-    path('swagger/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
-    path('redoc/', SpectacularRedocView.as_view(url_name='schema'), name='redoc'),
+    path("schema/", SpectacularAPIView.as_view(), name="schema"),
+    path(
+        "swagger/", SpectacularSwaggerView.as_view(url_name="schema"), name="swagger-ui"
+    ),
+    path("redoc/", SpectacularRedocView.as_view(url_name="schema"), name="redoc"),
     path("gateway/", include("authentication.urls")),
     path("users/", include("users.urls")),
     path("events/", include("events.urls")),
     path("venues/", include("venues.urls")),
     path("bookings/", include("bookings.urls")),
     path("comments/", include("comments.urls")),
-    path('api/nusmods/', include('nusmods.urls')),
+    path("api/nusmods/", include("nusmods.urls")),
 ]

--- a/backend/treeckle/treeckle/rest_api_urls.py
+++ b/backend/treeckle/treeckle/rest_api_urls.py
@@ -1,7 +1,10 @@
 from django.urls import include, path
-
+from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView, SpectacularRedocView
 
 urlpatterns = [
+    path('schema/', SpectacularAPIView.as_view(), name='schema'),
+    path('swagger/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
+    path('redoc/', SpectacularRedocView.as_view(url_name='schema'), name='redoc'),
     path("gateway/", include("authentication.urls")),
     path("users/", include("users.urls")),
     path("events/", include("events.urls")),

--- a/backend/treeckle/treeckle/settings.py
+++ b/backend/treeckle/treeckle/settings.py
@@ -180,7 +180,7 @@ REST_FRAMEWORK = {
     "DEFAULT_PERMISSION_CLASSES": ("rest_framework.permissions.IsAuthenticated",),
     "DEFAULT_RENDERER_CLASSES": (
         "djangorestframework_camel_case.render.CamelCaseJSONRenderer",
-        "djangorestframework_camel_case.render.CamelCaseBrowsableAPIRenderer",  
+        "djangorestframework_camel_case.render.CamelCaseBrowsableAPIRenderer",
     ),
     "DEFAULT_PARSER_CLASSES": (
         "djangorestframework_camel_case.parser.CamelCaseJSONParser",
@@ -192,10 +192,10 @@ REST_FRAMEWORK = {
 }
 
 SPECTACULAR_SETTINGS = {
-    'TITLE': 'Treeckle API',
-    'DESCRIPTION': 'API documentation for Treeckle booking system',
-    'VERSION': '3.0.0',
-    'SERVE_INCLUDE_SCHEMA': False,
+    "TITLE": "Treeckle API",
+    "DESCRIPTION": "API documentation for Treeckle booking system",
+    "VERSION": "3.0.0",
+    "SERVE_INCLUDE_SCHEMA": False,
 }
 
 

--- a/backend/treeckle/treeckle/settings.py
+++ b/backend/treeckle/treeckle/settings.py
@@ -50,6 +50,7 @@ INSTALLED_APPS = [
     "django.contrib.sites",
     "django.contrib.flatpages",
     "anymail",
+    "drf_spectacular",
     "treeckle",
     "organizations",
     "email_service",
@@ -187,6 +188,14 @@ REST_FRAMEWORK = {
     "JSON_UNDERSCOREIZE": {
         "no_underscore_before_number": True,
     },
+    "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
+}
+
+SPECTACULAR_SETTINGS = {
+    'TITLE': 'Treeckle API',
+    'DESCRIPTION': 'API documentation for Treeckle booking system',
+    'VERSION': '3.0.0',
+    'SERVE_INCLUDE_SCHEMA': False,
 }
 
 

--- a/backend/treeckle/users/tests.py
+++ b/backend/treeckle/users/tests.py
@@ -1,2 +1,1 @@
-
 # Create your tests here.

--- a/backend/treeckle/users/views.py
+++ b/backend/treeckle/users/views.py
@@ -45,13 +45,13 @@ from .serializers import (
                         "role": "RESIDENT",
                         "organization": "Test Organization",
                         "createdAt": 1647875400000,
-                        "updatedAt": 1647875400000
+                        "updatedAt": 1647875400000,
                     }
-                ]
+                ],
             },
             401: {"description": "Authentication required"},
-            403: {"description": "Admin access required"}
-        }
+            403: {"description": "Admin access required"},
+        },
     ),
     post=extend_schema(
         summary="Create User Invitations",
@@ -61,14 +61,8 @@ from .serializers import (
             "application/json": {
                 "example": {
                     "invitations": [
-                        {
-                            "email": "newuser@example.com",
-                            "role": "RESIDENT"
-                        },
-                        {
-                            "email": "organizer@example.com", 
-                            "role": "ORGANIZER"
-                        }
+                        {"email": "newuser@example.com", "role": "RESIDENT"},
+                        {"email": "organizer@example.com", "role": "ORGANIZER"},
                     ]
                 }
             }
@@ -83,21 +77,22 @@ from .serializers import (
                         "role": "RESIDENT",
                         "organization": "Test Organization",
                         "createdAt": 1647875400000,
-                        "updatedAt": 1647875400000
+                        "updatedAt": 1647875400000,
                     }
-                ]
+                ],
             },
             400: {"description": "Invalid invitation data"},
             401: {"description": "Authentication required"},
-            403: {"description": "Admin access required"}        }
-    )
+            403: {"description": "Admin access required"},
+        },
+    ),
 )
 class UserInvitesView(APIView):
     @check_access(Role.ADMIN)
     def get(self, request, requester: User):
         """
         Retrieve all pending user invitations for the requester's organization.
-        
+
         Returns a list of user invitations that are pending acceptance,
         filtered by the requester's organization.
         """
@@ -116,7 +111,7 @@ class UserInvitesView(APIView):
     def post(self, request, requester: User):
         """
         Create user invitations and send invitation emails.
-        
+
         Validates invitation data, filters out existing users/invitations,
         creates new user invitations, and sends email invitations to valid users.
         """
@@ -147,13 +142,7 @@ class UserInvitesView(APIView):
         summary="Update User Invitation",
         description="Update a user invitation's role. Admin access required.",
         tags=["User Invitations"],
-        request={
-            "application/json": {
-                "example": {
-                    "role": "ORGANIZER"
-                }
-            }
-        },
+        request={"application/json": {"example": {"role": "ORGANIZER"}}},
         responses={
             200: {
                 "description": "User invitation updated successfully",
@@ -163,14 +152,14 @@ class UserInvitesView(APIView):
                     "role": "ORGANIZER",
                     "organization": "Test Organization",
                     "createdAt": 1647875400000,
-                    "updatedAt": 1647875500000
-                }
+                    "updatedAt": 1647875500000,
+                },
             },
             400: {"description": "Invalid role data"},
             401: {"description": "Authentication required"},
             403: {"description": "Admin access required"},
-            404: {"description": "User invitation not found"}
-        }
+            404: {"description": "User invitation not found"},
+        },
     ),
     delete=extend_schema(
         summary="Delete User Invitation",
@@ -185,13 +174,14 @@ class UserInvitesView(APIView):
                     "role": "RESIDENT",
                     "organization": "Test Organization",
                     "createdAt": 1647875400000,
-                    "updatedAt": 1647875400000
-                }
+                    "updatedAt": 1647875400000,
+                },
             },
             401: {"description": "Authentication required"},
             403: {"description": "Admin access required"},
-            404: {"description": "User invitation not found"}        }
-    )
+            404: {"description": "User invitation not found"},
+        },
+    ),
 )
 class SingleUserInviteView(APIView):
     @check_access(Role.ADMIN)
@@ -199,7 +189,7 @@ class SingleUserInviteView(APIView):
     def patch(self, request, requester: User, user_invite: UserInvite):
         """
         Update a user invitation's role.
-        
+
         Allows admins to modify the role of a pending user invitation
         within the same organization.
         """
@@ -218,7 +208,7 @@ class SingleUserInviteView(APIView):
     def delete(self, request, requester: User, user_invite: UserInvite):
         """
         Delete a pending user invitation.
-        
+
         Allows admins to cancel a user invitation that hasn't been accepted yet.
         Returns the deleted invitation data.
         """
@@ -246,7 +236,7 @@ class SingleUserInviteView(APIView):
                         "profileImage": "https://example.com/profile.jpg",
                         "isSelf": True,
                         "createdAt": 1647875400000,
-                        "updatedAt": 1647875400000
+                        "updatedAt": 1647875400000,
                     },
                     {
                         "id": 2,
@@ -257,13 +247,13 @@ class SingleUserInviteView(APIView):
                         "profileImage": None,
                         "isSelf": False,
                         "createdAt": 1647875500000,
-                        "updatedAt": 1647875500000
-                    }
-                ]
+                        "updatedAt": 1647875500000,
+                    },
+                ],
             },
             401: {"description": "Authentication required"},
-            403: {"description": "Admin access required"}
-        }
+            403: {"description": "Admin access required"},
+        },
     )
 )
 class UsersView(APIView):
@@ -271,7 +261,7 @@ class UsersView(APIView):
     def get(self, request, requester: User):
         """
         Retrieve all users within the organization.
-        
+
         Returns a list of all users belonging to the same organization as the requester.
         Includes user profile information and marks which user is the requester (isSelf).
         """
@@ -306,15 +296,15 @@ class UsersView(APIView):
                     "hasPasswordAuth": True,
                     "googleAuth": {
                         "email": "john@gmail.com",
-                        "profileImage": "https://google.com/profile.jpg"
+                        "profileImage": "https://google.com/profile.jpg",
                     },
                     "facebookAuth": None,
                     "createdAt": 1647875400000,
-                    "updatedAt": 1647875400000
-                }
+                    "updatedAt": 1647875400000,
+                },
             },
-            401: {"description": "Authentication required"}
-        }
+            401: {"description": "Authentication required"},
+        },
     ),
     patch=extend_schema(
         summary="Update User Profile",
@@ -325,46 +315,37 @@ class UsersView(APIView):
                 "examples": {
                     "update_name": {
                         "summary": "Update Name",
-                        "value": {
-                            "action": "NAME",
-                            "payload": {"name": "New Name"}
-                        }
+                        "value": {"action": "NAME", "payload": {"name": "New Name"}},
                     },
                     "update_password": {
                         "summary": "Update Password",
                         "value": {
                             "action": "PASSWORD",
-                            "payload": {"password": "newpassword123"}
-                        }
+                            "payload": {"password": "newpassword123"},
+                        },
                     },
                     "link_google": {
                         "summary": "Link Google Account",
                         "value": {
                             "action": "GOOGLE",
-                            "payload": {"token": "google_token_here"}
-                        }
+                            "payload": {"token": "google_token_here"},
+                        },
                     },
                     "unlink_google": {
                         "summary": "Unlink Google Account",
-                        "value": {
-                            "action": "GOOGLE",
-                            "payload": None
-                        }
+                        "value": {"action": "GOOGLE", "payload": None},
                     },
                     "update_profile_image": {
                         "summary": "Update Profile Image",
                         "value": {
                             "action": "PROFILE_IMAGE",
-                            "payload": {"profile_image": "base64_image_data"}
-                        }
+                            "payload": {"profile_image": "base64_image_data"},
+                        },
                     },
                     "remove_profile_image": {
                         "summary": "Remove Profile Image",
-                        "value": {
-                            "action": "PROFILE_IMAGE",
-                            "payload": None
-                        }
-                    }
+                        "value": {"action": "PROFILE_IMAGE", "payload": None},
+                    },
                 }
             }
         },
@@ -382,24 +363,24 @@ class UsersView(APIView):
                     "hasPasswordAuth": True,
                     "googleAuth": {
                         "email": "john@gmail.com",
-                        "profileImage": "https://google.com/profile.jpg"
+                        "profileImage": "https://google.com/profile.jpg",
                     },
                     "facebookAuth": None,
                     "createdAt": 1647875400000,
-                    "updatedAt": 1647875400000
-                }
+                    "updatedAt": 1647875400000,
+                },
             },
             400: {"description": "Invalid action or payload data"},
-            401: {"description": "Authentication required"}
-        }
-    )
+            401: {"description": "Authentication required"},
+        },
+    ),
 )
 class RequesterView(APIView):
     @check_access(Role.RESIDENT, Role.ORGANIZER, Role.ADMIN)
     def get(self, request, requester: User):
         """
         Get the current user's detailed profile information.
-        
+
         Returns comprehensive profile data including authentication methods,
         profile image, and other user details for the authenticated user.
         """
@@ -411,10 +392,10 @@ class RequesterView(APIView):
     def patch(self, request, requester: User):
         """
         Update the current user's profile or authentication settings.
-        
+
         Supports various actions:
         - NAME: Update display name
-        - PROFILE_IMAGE: Upload/remove profile image  
+        - PROFILE_IMAGE: Upload/remove profile image
         - PASSWORD: Update password
         - GOOGLE: Link/unlink Google account
         - FACEBOOK: Link/unlink Facebook account
@@ -445,7 +426,7 @@ class RequesterView(APIView):
                 name="user_id",
                 type=int,
                 location=OpenApiParameter.PATH,
-                description="The ID of the user to retrieve"
+                description="The ID of the user to retrieve",
             )
         ],
         responses={
@@ -460,13 +441,13 @@ class RequesterView(APIView):
                     "profileImage": "https://example.com/profile.jpg",
                     "isSelf": False,
                     "createdAt": 1647875400000,
-                    "updatedAt": 1647875400000
-                }
+                    "updatedAt": 1647875400000,
+                },
             },
             401: {"description": "Authentication required"},
             403: {"description": "Access denied - insufficient permissions"},
-            404: {"description": "User not found or not in same organization"}
-        }
+            404: {"description": "User not found or not in same organization"},
+        },
     ),
     patch=extend_schema(
         summary="Update User",
@@ -477,7 +458,7 @@ class RequesterView(APIView):
                 name="user_id",
                 type=int,
                 location=OpenApiParameter.PATH,
-                description="The ID of the user to update"
+                description="The ID of the user to update",
             )
         ],
         request={
@@ -485,24 +466,24 @@ class RequesterView(APIView):
                 "examples": {
                     "update_name": {
                         "summary": "Update Name Only",
-                        "value": {"name": "Updated Name"}
+                        "value": {"name": "Updated Name"},
                     },
                     "update_email": {
                         "summary": "Update Email Only",
-                        "value": {"email": "newemail@example.com"}
+                        "value": {"email": "newemail@example.com"},
                     },
                     "update_role": {
                         "summary": "Update Role Only",
-                        "value": {"role": "ORGANIZER"}
+                        "value": {"role": "ORGANIZER"},
                     },
                     "update_multiple": {
                         "summary": "Update Multiple Fields",
                         "value": {
                             "name": "John Smith",
                             "email": "johnsmith@example.com",
-                            "role": "ADMIN"
-                        }
-                    }
+                            "role": "ADMIN",
+                        },
+                    },
                 }
             }
         },
@@ -518,14 +499,14 @@ class RequesterView(APIView):
                     "profileImage": "https://example.com/profile.jpg",
                     "isSelf": False,
                     "createdAt": 1647875400000,
-                    "updatedAt": 1647875400000
-                }
+                    "updatedAt": 1647875400000,
+                },
             },
             400: {"description": "Invalid data or cannot self-update role"},
             401: {"description": "Authentication required"},
             403: {"description": "Admin access required"},
-            404: {"description": "User not found or not in same organization"}
-        }
+            404: {"description": "User not found or not in same organization"},
+        },
     ),
     delete=extend_schema(
         summary="Delete User",
@@ -536,7 +517,7 @@ class RequesterView(APIView):
                 name="user_id",
                 type=int,
                 location=OpenApiParameter.PATH,
-                description="The ID of the user to delete"
+                description="The ID of the user to delete",
             )
         ],
         responses={
@@ -551,15 +532,15 @@ class RequesterView(APIView):
                     "profileImage": None,
                     "isSelf": False,
                     "createdAt": 1647875400000,
-                    "updatedAt": 1647875400000
-                }
+                    "updatedAt": 1647875400000,
+                },
             },
             400: {"description": "Cannot self-delete"},
             401: {"description": "Authentication required"},
             403: {"description": "Admin access required"},
-            404: {"description": "User not found or not in same organization"}
-        }
-    )
+            404: {"description": "User not found or not in same organization"},
+        },
+    ),
 )
 class SingleUserView(APIView):
     @check_access(Role.RESIDENT, Role.ORGANIZER, Role.ADMIN)
@@ -567,7 +548,7 @@ class SingleUserView(APIView):
     def get(self, request, requester: User, user: User):
         """
         Retrieve detailed information about a specific user.
-        
+
         All authenticated users can view profile information of users
         within their organization.
         """
@@ -580,7 +561,7 @@ class SingleUserView(APIView):
     def patch(self, request, requester: User, user: User):
         """
         Update a user's profile information.
-        
+
         Allows admins to update name, email, and role of users within
         their organization. Admins cannot modify their own role.
         """
@@ -603,7 +584,7 @@ class SingleUserView(APIView):
     def delete(self, request, requester: User, user: User):
         """
         Delete a user from the organization.
-        
+
         Allows admins to remove users from their organization.
         Admins cannot delete themselves. Returns the deleted user data.
         """

--- a/backend/treeckle/users/views.py
+++ b/backend/treeckle/users/views.py
@@ -1,6 +1,7 @@
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
+from drf_spectacular.utils import extend_schema, extend_schema_view, OpenApiParameter
 
 from treeckle.common.exceptions import BadRequest
 from email_service.logic import send_user_invite_emails
@@ -29,9 +30,77 @@ from .serializers import (
 
 
 # Create your views here.
+@extend_schema_view(
+    get=extend_schema(
+        summary="List User Invitations",
+        description="Retrieve all pending user invitations for the organization. Admin access required.",
+        tags=["User Invitations"],
+        responses={
+            200: {
+                "description": "List of user invitations retrieved successfully",
+                "example": [
+                    {
+                        "id": 1,
+                        "email": "user@example.com",
+                        "role": "RESIDENT",
+                        "organization": "Test Organization",
+                        "createdAt": 1647875400000,
+                        "updatedAt": 1647875400000
+                    }
+                ]
+            },
+            401: {"description": "Authentication required"},
+            403: {"description": "Admin access required"}
+        }
+    ),
+    post=extend_schema(
+        summary="Create User Invitations",
+        description="Send email invitations to new users to join the organization. Admin access required.",
+        tags=["User Invitations"],
+        request={
+            "application/json": {
+                "example": {
+                    "invitations": [
+                        {
+                            "email": "newuser@example.com",
+                            "role": "RESIDENT"
+                        },
+                        {
+                            "email": "organizer@example.com", 
+                            "role": "ORGANIZER"
+                        }
+                    ]
+                }
+            }
+        },
+        responses={
+            201: {
+                "description": "User invitations created and emails sent successfully",
+                "example": [
+                    {
+                        "id": 2,
+                        "email": "newuser@example.com",
+                        "role": "RESIDENT",
+                        "organization": "Test Organization",
+                        "createdAt": 1647875400000,
+                        "updatedAt": 1647875400000
+                    }
+                ]
+            },
+            400: {"description": "Invalid invitation data"},
+            401: {"description": "Authentication required"},
+            403: {"description": "Admin access required"}        }
+    )
+)
 class UserInvitesView(APIView):
     @check_access(Role.ADMIN)
     def get(self, request, requester: User):
+        """
+        Retrieve all pending user invitations for the requester's organization.
+        
+        Returns a list of user invitations that are pending acceptance,
+        filtered by the requester's organization.
+        """
         same_organization_user_invites = get_user_invites(
             organization=requester.organization
         ).select_related("organization")
@@ -45,6 +114,12 @@ class UserInvitesView(APIView):
 
     @check_access(Role.ADMIN)
     def post(self, request, requester: User):
+        """
+        Create user invitations and send invitation emails.
+        
+        Validates invitation data, filters out existing users/invitations,
+        creates new user invitations, and sends email invitations to valid users.
+        """
         serializer = PostUserInviteSerializer(data=request.data)
 
         serializer.is_valid(raise_exception=True)
@@ -67,10 +142,67 @@ class UserInvitesView(APIView):
         return Response(data, status=status.HTTP_201_CREATED)
 
 
+@extend_schema_view(
+    patch=extend_schema(
+        summary="Update User Invitation",
+        description="Update a user invitation's role. Admin access required.",
+        tags=["User Invitations"],
+        request={
+            "application/json": {
+                "example": {
+                    "role": "ORGANIZER"
+                }
+            }
+        },
+        responses={
+            200: {
+                "description": "User invitation updated successfully",
+                "example": {
+                    "id": 1,
+                    "email": "user@example.com",
+                    "role": "ORGANIZER",
+                    "organization": "Test Organization",
+                    "createdAt": 1647875400000,
+                    "updatedAt": 1647875500000
+                }
+            },
+            400: {"description": "Invalid role data"},
+            401: {"description": "Authentication required"},
+            403: {"description": "Admin access required"},
+            404: {"description": "User invitation not found"}
+        }
+    ),
+    delete=extend_schema(
+        summary="Delete User Invitation",
+        description="Delete a pending user invitation. Admin access required.",
+        tags=["User Invitations"],
+        responses={
+            200: {
+                "description": "User invitation deleted successfully",
+                "example": {
+                    "id": 1,
+                    "email": "user@example.com",
+                    "role": "RESIDENT",
+                    "organization": "Test Organization",
+                    "createdAt": 1647875400000,
+                    "updatedAt": 1647875400000
+                }
+            },
+            401: {"description": "Authentication required"},
+            403: {"description": "Admin access required"},
+            404: {"description": "User invitation not found"}        }
+    )
+)
 class SingleUserInviteView(APIView):
     @check_access(Role.ADMIN)
     @check_requester_user_invite_same_organization
     def patch(self, request, requester: User, user_invite: UserInvite):
+        """
+        Update a user invitation's role.
+        
+        Allows admins to modify the role of a pending user invitation
+        within the same organization.
+        """
         serializer = PatchSingleUserInviteSerializer(data=request.data)
 
         serializer.is_valid(raise_exception=True)
@@ -84,15 +216,65 @@ class SingleUserInviteView(APIView):
     @check_access(Role.ADMIN)
     @check_requester_user_invite_same_organization
     def delete(self, request, requester: User, user_invite: UserInvite):
+        """
+        Delete a pending user invitation.
+        
+        Allows admins to cancel a user invitation that hasn't been accepted yet.
+        Returns the deleted invitation data.
+        """
         data = user_invite_to_json(user_invite)
         user_invite.delete()
 
         return Response(data, status=status.HTTP_200_OK)
 
 
+@extend_schema_view(
+    get=extend_schema(
+        summary="List Organization Users",
+        description="Retrieve all users within the same organization. Admin access required.",
+        tags=["Users"],
+        responses={
+            200: {
+                "description": "List of users retrieved successfully",
+                "example": [
+                    {
+                        "id": 1,
+                        "name": "John Doe",
+                        "email": "john@example.com",
+                        "organization": "Test Organization",
+                        "role": "ADMIN",
+                        "profileImage": "https://example.com/profile.jpg",
+                        "isSelf": True,
+                        "createdAt": 1647875400000,
+                        "updatedAt": 1647875400000
+                    },
+                    {
+                        "id": 2,
+                        "name": "Jane Smith",
+                        "email": "jane@example.com",
+                        "organization": "Test Organization",
+                        "role": "RESIDENT",
+                        "profileImage": None,
+                        "isSelf": False,
+                        "createdAt": 1647875500000,
+                        "updatedAt": 1647875500000
+                    }
+                ]
+            },
+            401: {"description": "Authentication required"},
+            403: {"description": "Admin access required"}
+        }
+    )
+)
 class UsersView(APIView):
     @check_access(Role.ADMIN)
     def get(self, request, requester: User):
+        """
+        Retrieve all users within the organization.
+        
+        Returns a list of all users belonging to the same organization as the requester.
+        Includes user profile information and marks which user is the requester (isSelf).
+        """
         same_organization_users = get_users(
             organization=requester.organization
         ).select_related("organization", "profile_image")
@@ -105,15 +287,138 @@ class UsersView(APIView):
         return Response(data, status=status.HTTP_200_OK)
 
 
+@extend_schema_view(
+    get=extend_schema(
+        summary="Get Current User Profile",
+        description="Retrieve the current authenticated user's detailed profile information including authentication methods.",
+        tags=["User Profile"],
+        responses={
+            200: {
+                "description": "User profile retrieved successfully",
+                "example": {
+                    "id": 1,
+                    "name": "John Doe",
+                    "email": "john@example.com",
+                    "organization": "Test Organization",
+                    "role": "ADMIN",
+                    "profileImage": "https://example.com/profile.jpg",
+                    "isSelf": True,
+                    "hasPasswordAuth": True,
+                    "googleAuth": {
+                        "email": "john@gmail.com",
+                        "profileImage": "https://google.com/profile.jpg"
+                    },
+                    "facebookAuth": None,
+                    "createdAt": 1647875400000,
+                    "updatedAt": 1647875400000
+                }
+            },
+            401: {"description": "Authentication required"}
+        }
+    ),
+    patch=extend_schema(
+        summary="Update User Profile",
+        description="Update the current user's profile or authentication settings. Supports updating name, profile image, password, and linking/unlinking social accounts.",
+        tags=["User Profile"],
+        request={
+            "application/json": {
+                "examples": {
+                    "update_name": {
+                        "summary": "Update Name",
+                        "value": {
+                            "action": "NAME",
+                            "payload": {"name": "New Name"}
+                        }
+                    },
+                    "update_password": {
+                        "summary": "Update Password",
+                        "value": {
+                            "action": "PASSWORD",
+                            "payload": {"password": "newpassword123"}
+                        }
+                    },
+                    "link_google": {
+                        "summary": "Link Google Account",
+                        "value": {
+                            "action": "GOOGLE",
+                            "payload": {"token": "google_token_here"}
+                        }
+                    },
+                    "unlink_google": {
+                        "summary": "Unlink Google Account",
+                        "value": {
+                            "action": "GOOGLE",
+                            "payload": None
+                        }
+                    },
+                    "update_profile_image": {
+                        "summary": "Update Profile Image",
+                        "value": {
+                            "action": "PROFILE_IMAGE",
+                            "payload": {"profile_image": "base64_image_data"}
+                        }
+                    },
+                    "remove_profile_image": {
+                        "summary": "Remove Profile Image",
+                        "value": {
+                            "action": "PROFILE_IMAGE",
+                            "payload": None
+                        }
+                    }
+                }
+            }
+        },
+        responses={
+            200: {
+                "description": "User profile updated successfully",
+                "example": {
+                    "id": 1,
+                    "name": "Updated Name",
+                    "email": "john@example.com",
+                    "organization": "Test Organization",
+                    "role": "ADMIN",
+                    "profileImage": "https://example.com/new-profile.jpg",
+                    "isSelf": True,
+                    "hasPasswordAuth": True,
+                    "googleAuth": {
+                        "email": "john@gmail.com",
+                        "profileImage": "https://google.com/profile.jpg"
+                    },
+                    "facebookAuth": None,
+                    "createdAt": 1647875400000,
+                    "updatedAt": 1647875400000
+                }
+            },
+            400: {"description": "Invalid action or payload data"},
+            401: {"description": "Authentication required"}
+        }
+    )
+)
 class RequesterView(APIView):
     @check_access(Role.RESIDENT, Role.ORGANIZER, Role.ADMIN)
     def get(self, request, requester: User):
+        """
+        Get the current user's detailed profile information.
+        
+        Returns comprehensive profile data including authentication methods,
+        profile image, and other user details for the authenticated user.
+        """
         data = requester_to_json(requester)
 
         return Response(data, status=status.HTTP_200_OK)
 
     @check_access(Role.RESIDENT, Role.ORGANIZER, Role.ADMIN)
     def patch(self, request, requester: User):
+        """
+        Update the current user's profile or authentication settings.
+        
+        Supports various actions:
+        - NAME: Update display name
+        - PROFILE_IMAGE: Upload/remove profile image  
+        - PASSWORD: Update password
+        - GOOGLE: Link/unlink Google account
+        - FACEBOOK: Link/unlink Facebook account
+        """
         serializer = PatchRequesterSerializer(data=request.data)
 
         serializer.is_valid(raise_exception=True)
@@ -130,10 +435,142 @@ class RequesterView(APIView):
         return Response(data, status=status.HTTP_200_OK)
 
 
+@extend_schema_view(
+    get=extend_schema(
+        summary="Get User Details",
+        description="Retrieve detailed information about a specific user. All authenticated users can view users from their organization.",
+        tags=["Users"],
+        parameters=[
+            OpenApiParameter(
+                name="user_id",
+                type=int,
+                location=OpenApiParameter.PATH,
+                description="The ID of the user to retrieve"
+            )
+        ],
+        responses={
+            200: {
+                "description": "User details retrieved successfully",
+                "example": {
+                    "id": 2,
+                    "name": "Jane Smith",
+                    "email": "jane@example.com",
+                    "organization": "Test Organization",
+                    "role": "RESIDENT",
+                    "profileImage": "https://example.com/profile.jpg",
+                    "isSelf": False,
+                    "createdAt": 1647875400000,
+                    "updatedAt": 1647875400000
+                }
+            },
+            401: {"description": "Authentication required"},
+            403: {"description": "Access denied - insufficient permissions"},
+            404: {"description": "User not found or not in same organization"}
+        }
+    ),
+    patch=extend_schema(
+        summary="Update User",
+        description="Update a user's profile information. Only admins can update users, and cannot modify their own role.",
+        tags=["Users"],
+        parameters=[
+            OpenApiParameter(
+                name="user_id",
+                type=int,
+                location=OpenApiParameter.PATH,
+                description="The ID of the user to update"
+            )
+        ],
+        request={
+            "application/json": {
+                "examples": {
+                    "update_name": {
+                        "summary": "Update Name Only",
+                        "value": {"name": "Updated Name"}
+                    },
+                    "update_email": {
+                        "summary": "Update Email Only",
+                        "value": {"email": "newemail@example.com"}
+                    },
+                    "update_role": {
+                        "summary": "Update Role Only",
+                        "value": {"role": "ORGANIZER"}
+                    },
+                    "update_multiple": {
+                        "summary": "Update Multiple Fields",
+                        "value": {
+                            "name": "John Smith",
+                            "email": "johnsmith@example.com",
+                            "role": "ADMIN"
+                        }
+                    }
+                }
+            }
+        },
+        responses={
+            200: {
+                "description": "User updated successfully",
+                "example": {
+                    "id": 2,
+                    "name": "Updated Name",
+                    "email": "newemail@example.com",
+                    "organization": "Test Organization",
+                    "role": "ORGANIZER",
+                    "profileImage": "https://example.com/profile.jpg",
+                    "isSelf": False,
+                    "createdAt": 1647875400000,
+                    "updatedAt": 1647875400000
+                }
+            },
+            400: {"description": "Invalid data or cannot self-update role"},
+            401: {"description": "Authentication required"},
+            403: {"description": "Admin access required"},
+            404: {"description": "User not found or not in same organization"}
+        }
+    ),
+    delete=extend_schema(
+        summary="Delete User",
+        description="Delete a user from the organization. Admins cannot delete themselves.",
+        tags=["Users"],
+        parameters=[
+            OpenApiParameter(
+                name="user_id",
+                type=int,
+                location=OpenApiParameter.PATH,
+                description="The ID of the user to delete"
+            )
+        ],
+        responses={
+            200: {
+                "description": "User deleted successfully",
+                "example": {
+                    "id": 2,
+                    "name": "Deleted User",
+                    "email": "deleted@example.com",
+                    "organization": "Test Organization",
+                    "role": "RESIDENT",
+                    "profileImage": None,
+                    "isSelf": False,
+                    "createdAt": 1647875400000,
+                    "updatedAt": 1647875400000
+                }
+            },
+            400: {"description": "Cannot self-delete"},
+            401: {"description": "Authentication required"},
+            403: {"description": "Admin access required"},
+            404: {"description": "User not found or not in same organization"}
+        }
+    )
+)
 class SingleUserView(APIView):
     @check_access(Role.RESIDENT, Role.ORGANIZER, Role.ADMIN)
     @check_requester_user_same_organization
     def get(self, request, requester: User, user: User):
+        """
+        Retrieve detailed information about a specific user.
+        
+        All authenticated users can view profile information of users
+        within their organization.
+        """
         data = user_to_json(user=user, requester=requester)
 
         return Response(data, status=status.HTTP_200_OK)
@@ -141,6 +578,12 @@ class SingleUserView(APIView):
     @check_access(Role.ADMIN)
     @check_requester_user_same_organization
     def patch(self, request, requester: User, user: User):
+        """
+        Update a user's profile information.
+        
+        Allows admins to update name, email, and role of users within
+        their organization. Admins cannot modify their own role.
+        """
         serializer = PatchSingleUserSerializer(data=request.data)
 
         serializer.is_valid(raise_exception=True)
@@ -158,6 +601,12 @@ class SingleUserView(APIView):
     @check_access(Role.ADMIN)
     @check_requester_user_same_organization
     def delete(self, request, requester: User, user: User):
+        """
+        Delete a user from the organization.
+        
+        Allows admins to remove users from their organization.
+        Admins cannot delete themselves. Returns the deleted user data.
+        """
         if requester == user:
             raise BadRequest(detail="Cannot self-delete", code="self_delete")
 

--- a/backend/treeckle/venues/tests.py
+++ b/backend/treeckle/venues/tests.py
@@ -1,2 +1,1 @@
-
 # Create your tests here.

--- a/backend/treeckle/venues/views.py
+++ b/backend/treeckle/venues/views.py
@@ -3,6 +3,7 @@ from django.db import IntegrityError
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
+from drf_spectacular.utils import extend_schema, extend_schema_view, OpenApiParameter
 
 from treeckle.common.exceptions import Conflict
 from users.permission_middlewares import check_access
@@ -31,9 +32,36 @@ from .logic import (
 # Create your views here.
 
 
+@extend_schema_view(
+    get=extend_schema(
+        summary="Get Venue Categories",
+        description="Retrieve all available venue categories within the user's organization. Used for filtering and categorizing venues.",
+        responses={
+            200: {
+                "description": "List of venue categories",
+                "example": [
+                    "Conference Rooms",
+                    "Sports Facilities", 
+                    "Study Rooms",
+                    "Event Halls",
+                    "Outdoor Spaces"
+                ]
+            },
+            401: {"description": "Authentication required"},
+            403: {"description": "Insufficient permissions"}
+        },
+        tags=["Venues"]
+    )
+)
 class VenueCategoriesView(APIView):
     @check_access(Role.RESIDENT, Role.ORGANIZER, Role.ADMIN)
     def get(self, request, requester: User):
+        """
+        Get all venue categories in the user's organization.
+        
+        Returns a list of category names that can be used for filtering venues
+        or creating new venues. Only includes categories from the same organization.
+        """
         same_organization_venue_categories = get_venue_categories(
             organization=requester.organization
         )
@@ -45,9 +73,51 @@ class VenueCategoriesView(APIView):
         return Response(data, status=status.HTTP_200_OK)
 
 
+@extend_schema_view(
+    get=extend_schema(
+        summary="Get Booking Notification Subscriptions",
+        description="Retrieve all booking notification subscriptions for venues in the organization. Admin-only access.",
+        responses={
+            200: {
+                "description": "List of all booking notification subscriptions",
+                "example": [
+                    {
+                        "id": 1,
+                        "name": "Facilities Manager",
+                        "email": "facilities@university.edu",
+                        "venue": {
+                            "id": 5,
+                            "name": "Main Conference Room",
+                            "category": "Conference Rooms"
+                        }
+                    },
+                    {
+                        "id": 2,
+                        "name": "Sports Coordinator",
+                        "email": "sports@university.edu",
+                        "venue": {
+                            "id": 8,
+                            "name": "Basketball Court A",
+                            "category": "Sports Facilities"
+                        }
+                    }
+                ]
+            },
+            401: {"description": "Authentication required"},
+            403: {"description": "Admin access required"}
+        },
+        tags=["Venue Notifications"]
+    )
+)
 class BookingNotificationSubscriptionsView(APIView):
     @check_access(Role.ADMIN)
     def get(self, request, requester: User):
+        """
+        Get all booking notification subscriptions in the organization.
+        
+        Returns subscriptions for all venues in the organization, showing
+        who should be notified when bookings are made for each venue.
+        """
         subscriptions = get_booking_notification_subscriptions(
             venue__organization=requester.organization
         ).select_related("venue")
@@ -60,10 +130,60 @@ class BookingNotificationSubscriptionsView(APIView):
         return Response(data, status=status.HTTP_200_OK)
 
 
+@extend_schema_view(
+    post=extend_schema(
+        summary="Create Booking Notification Subscription",
+        description="Create a new booking notification subscription for a specific venue. Admin-only access.",
+        parameters=[
+            OpenApiParameter(
+                name="venue_id",
+                description="Unique identifier of the venue to create subscription for",
+                required=True,
+                type=int,
+                location=OpenApiParameter.PATH
+            )
+        ],
+        request=PostBookingNotificationSubscriptionSerializer,
+        responses={
+            201: {
+                "description": "Subscription created successfully",
+                "example": {
+                    "id": 3,
+                    "name": "Event Coordinator",
+                    "email": "events@university.edu",
+                    "venue": {
+                        "id": 12,
+                        "name": "Auditorium",
+                        "category": "Event Halls"
+                    }
+                }
+            },
+            400: {"description": "Invalid input data"},
+            401: {"description": "Authentication required"},
+            403: {"description": "Admin access required"},
+            404: {"description": "Venue not found"},
+            409: {
+                "description": "Subscription already exists",
+                "example": {
+                    "detail": "Booking notification subscription already exists.",
+                    "code": "booking_notification_subscription_exists"
+                }
+            }
+        },
+        tags=["Venue Notifications"]
+    )
+)
 class SingleVenueBookingNotificationSubscriptionsView(APIView):
     @check_access(Role.ADMIN)
     @check_requester_venue_same_organization
     def post(self, request, requester: User, venue: Venue):
+        """
+        Create a booking notification subscription for a venue.
+        
+        Creates a new subscription that will send notifications to the specified
+        email address when bookings are made for this venue. Each email can only
+        have one subscription per venue.
+        """
         serializer = PostBookingNotificationSubscriptionSerializer(data=request.data)
 
         serializer.is_valid(raise_exception=True)
@@ -86,6 +206,40 @@ class SingleVenueBookingNotificationSubscriptionsView(APIView):
         return Response(data, status=status.HTTP_201_CREATED)
 
 
+@extend_schema_view(
+    delete=extend_schema(
+        summary="Delete Booking Notification Subscription",
+        description="Delete a specific booking notification subscription. Admin-only access.",
+        parameters=[
+            OpenApiParameter(
+                name="subscription_id",
+                description="Unique identifier of the subscription to delete",
+                required=True,
+                type=int,
+                location=OpenApiParameter.PATH
+            )
+        ],
+        responses={
+            200: {
+                "description": "Subscription deleted successfully",
+                "example": {
+                    "id": 3,
+                    "name": "Event Coordinator",
+                    "email": "events@university.edu",
+                    "venue": {
+                        "id": 12,
+                        "name": "Auditorium",
+                        "category": "Event Halls"
+                    }
+                }
+            },
+            401: {"description": "Authentication required"},
+            403: {"description": "Admin access required"},
+            404: {"description": "Subscription not found"}
+        },
+        tags=["Venue Notifications"]
+    )
+)
 class SingleBookingNotificationSubscriptionView(APIView):
     @check_access(Role.ADMIN)
     @check_requester_booking_notification_subscription_same_organization
@@ -95,15 +249,133 @@ class SingleBookingNotificationSubscriptionView(APIView):
         requester: User,
         subscription: BookingNotificationSubscription,
     ):
+        """
+        Delete a booking notification subscription.
+        
+        Permanently removes the subscription, stopping future notifications
+        for bookings made to the associated venue.
+        """
         data = booking_notification_subscription_to_json(subscription)
         subscription.delete()
 
         return Response(data, status=status.HTTP_200_OK)
 
 
+@extend_schema_view(
+    get=extend_schema(
+        summary="Get Venues",
+        description="Retrieve venues in the organization with optional filtering by category and detail level. Supports both basic venue info and full details including booking forms.",
+        parameters=[
+            OpenApiParameter(
+                name="category",
+                description="Filter venues by category name",
+                required=False,
+                type=str,
+                location=OpenApiParameter.QUERY
+            ),
+            OpenApiParameter(
+                name="full_details",
+                description="Include full venue details including form fields and contact information",
+                required=False,
+                type=bool,
+                location=OpenApiParameter.QUERY
+            )
+        ],
+        responses={
+            200: {
+                "description": "List of venues (format depends on full_details parameter)",
+                "example": [
+                    {
+                        "id": 15,
+                        "name": "Conference Room A",
+                        "category": {
+                            "id": 3,
+                            "name": "Conference Rooms"
+                        },
+                        "capacity": 25,
+                        "ic_name": "John Manager",
+                        "ic_email": "john.manager@university.edu",
+                        "ic_contact_number": "+65 9123 4567",
+                        "form_field_data": [
+                            {
+                                "field_name": "Purpose",
+                                "field_type": "text",
+                                "is_required": True
+                            },
+                            {
+                                "field_name": "Equipment Needed",
+                                "field_type": "checkbox",
+                                "is_required": False,
+                                "options": ["Projector", "Microphone", "Whiteboard"]
+                            }
+                        ],
+                        "organization": {
+                            "id": 1,
+                            "name": "University College"
+                        }
+                    }
+                ]
+            },
+            400: {"description": "Invalid query parameters"},
+            401: {"description": "Authentication required"}
+        },
+        tags=["Venues"]
+    ),
+    post=extend_schema(
+        summary="Create New Venue",
+        description="Create a new venue in the organization. Admin-only access. Venue categories will be automatically created if they don't exist.",
+        request=VenueSerializer,
+        responses={
+            201: {
+                "description": "Venue created successfully",
+                "example": {
+                    "id": 20,
+                    "name": "Study Room B",
+                    "category": {
+                        "id": 5,
+                        "name": "Study Rooms"
+                    },
+                    "capacity": 8,
+                    "ic_name": "Library Staff",
+                    "ic_email": "library@university.edu",
+                    "ic_contact_number": "+65 9876 5432",
+                    "form_field_data": [
+                        {
+                            "field_name": "Number of Students",
+                            "field_type": "number",
+                            "is_required": True
+                        }
+                    ],
+                    "organization": {
+                        "id": 1,
+                        "name": "University College"
+                    }
+                }
+            },
+            400: {"description": "Invalid input data"},
+            401: {"description": "Authentication required"},
+            403: {"description": "Admin access required"},
+            409: {
+                "description": "Venue already exists",
+                "example": {
+                    "detail": "Venue already exists.",
+                    "code": "venue_exists"
+                }
+            }
+        },
+        tags=["Venues"]
+    )
+)
 class VenuesView(APIView):
     @check_access(Role.RESIDENT, Role.ORGANIZER, Role.ADMIN)
     def get(self, request, requester: User):
+        """
+        Get venues in the organization.
+        
+        Returns venues filtered by optional category parameter. The full_details
+        parameter controls whether to include complete venue information including
+        form fields and contact details, or just basic venue data.
+        """
         serializer = GetVenueSerializer(data=request.query_params.dict())
 
         serializer.is_valid(raise_exception=True)
@@ -125,6 +397,13 @@ class VenuesView(APIView):
 
     @check_access(Role.ADMIN)
     def post(self, request, requester: User):
+        """
+        Create a new venue.
+        
+        Creates a venue with the provided details including custom form fields
+        for booking requirements. Venue categories will be automatically created
+        if they don't exist in the organization.
+        """
         serializer = VenueSerializer(data=request.data)
 
         serializer.is_valid(raise_exception=True)
@@ -149,10 +428,169 @@ class VenuesView(APIView):
         return Response(data, status=status.HTTP_201_CREATED)
 
 
+@extend_schema_view(
+    get=extend_schema(
+        summary="Get Single Venue Details",
+        description="Retrieve detailed information about a specific venue including all form fields and contact information.",
+        parameters=[
+            OpenApiParameter(
+                name="venue_id",
+                description="Unique identifier of the venue",
+                required=True,
+                type=int,
+                location=OpenApiParameter.PATH
+            )
+        ],
+        responses={
+            200: {
+                "description": "Detailed venue information",
+                "example": {
+                    "id": 25,
+                    "name": "Main Auditorium",
+                    "category": {
+                        "id": 8,
+                        "name": "Event Halls"
+                    },
+                    "capacity": 500,
+                    "ic_name": "Events Manager",
+                    "ic_email": "events.manager@university.edu",
+                    "ic_contact_number": "+65 9111 2222",
+                    "form_field_data": [
+                        {
+                            "field_name": "Event Type",
+                            "field_type": "select",
+                            "is_required": True,
+                            "options": ["Conference", "Seminar", "Performance", "Graduation"]
+                        },
+                        {
+                            "field_name": "Expected Attendance",
+                            "field_type": "number",
+                            "is_required": True
+                        },
+                        {
+                            "field_name": "Technical Requirements",
+                            "field_type": "textarea",
+                            "is_required": False
+                        }
+                    ],
+                    "organization": {
+                        "id": 1,
+                        "name": "University College"
+                    }
+                }
+            },
+            401: {"description": "Authentication required"},
+            403: {"description": "Not authorized to view this venue"},
+            404: {"description": "Venue not found"}
+        },
+        tags=["Venues"]
+    ),
+    put=extend_schema(
+        summary="Update Venue",
+        description="Update an existing venue's details including name, category, capacity, contact information, and form fields. Admin-only access.",
+        parameters=[
+            OpenApiParameter(
+                name="venue_id",
+                description="Unique identifier of the venue to update",
+                required=True,
+                type=int,
+                location=OpenApiParameter.PATH
+            )
+        ],
+        request=VenueSerializer,
+        responses={
+            200: {
+                "description": "Venue updated successfully",
+                "example": {
+                    "id": 25,
+                    "name": "Updated Auditorium Name",
+                    "category": {
+                        "id": 8,
+                        "name": "Event Halls"
+                    },
+                    "capacity": 450,
+                    "ic_name": "New Events Manager",
+                    "ic_email": "new.events@university.edu",
+                    "ic_contact_number": "+65 9333 4444",
+                    "form_field_data": [
+                        {
+                            "field_name": "Event Type",
+                            "field_type": "select",
+                            "is_required": True,
+                            "options": ["Conference", "Seminar", "Performance", "Graduation", "Workshop"]
+                        }
+                    ],
+                    "organization": {
+                        "id": 1,
+                        "name": "University College"
+                    }
+                }
+            },
+            400: {"description": "Invalid input data"},
+            401: {"description": "Authentication required"},
+            403: {"description": "Admin access required"},
+            404: {"description": "Venue not found"},
+            409: {
+                "description": "Venue name already exists",
+                "example": {
+                    "detail": "Venue already exists.",
+                    "code": "venue_exists"
+                }
+            }
+        },
+        tags=["Venues"]
+    ),
+    delete=extend_schema(
+        summary="Delete Venue",
+        description="Delete an existing venue. This will also remove all associated bookings and clean up unused venue categories. Admin-only access.",
+        parameters=[
+            OpenApiParameter(
+                name="venue_id",
+                description="Unique identifier of the venue to delete",
+                required=True,
+                type=int,
+                location=OpenApiParameter.PATH
+            )
+        ],
+        responses={
+            200: {
+                "description": "Venue deleted successfully",
+                "example": {
+                    "id": 25,
+                    "name": "Deleted Venue",
+                    "category": {
+                        "id": 8,
+                        "name": "Event Halls"
+                    },
+                    "capacity": 450,
+                    "ic_name": "Events Manager",
+                    "ic_email": "events@university.edu",
+                    "ic_contact_number": "+65 9333 4444",
+                    "form_field_data": [],
+                    "organization": {
+                        "id": 1,
+                        "name": "University College"
+                    }
+                }
+            },
+            401: {"description": "Authentication required"},
+            403: {"description": "Admin access required"},
+            404: {"description": "Venue not found"}
+        },
+        tags=["Venues"]
+    )
+)
 class SingleVenueView(APIView):
     @check_access(Role.RESIDENT, Role.ORGANIZER, Role.ADMIN)
     @check_requester_venue_same_organization
     def get(self, request, requester: User, venue: Venue):
+        """
+        Get detailed information about a specific venue.
+        
+        Returns complete venue details including form fields, contact information,
+        and organization details. Accessible to all authenticated users in the
+        same organization.
+        """
         data = venue_to_json(venue, full_details=True)
 
         return Response(data, status=status.HTTP_200_OK)
@@ -160,6 +598,13 @@ class SingleVenueView(APIView):
     @check_access(Role.ADMIN)
     @check_requester_venue_same_organization
     def put(self, request, requester: User, venue: Venue):
+        """
+        Update an existing venue.
+        
+        Updates venue details including name, category, capacity, contact information,
+        and custom form fields. Venue categories will be created if they don't exist.
+        Only admins can update venues.
+        """
         serializer = VenueSerializer(data=request.data)
 
         serializer.is_valid(raise_exception=True)
@@ -187,6 +632,13 @@ class SingleVenueView(APIView):
     @check_access(Role.ADMIN)
     @check_requester_venue_same_organization
     def delete(self, request, requester: User, venue: Venue):
+        """
+        Delete an existing venue.
+        
+        Permanently removes the venue and all associated data including bookings
+        and notification subscriptions. Also cleans up any unused venue categories
+        within the organization. Only admins can delete venues.
+        """
         data = venue_to_json(venue, full_details=True)
         venue.delete()
         delete_unused_venue_categories(organization=venue.organization)

--- a/backend/treeckle/venues/views.py
+++ b/backend/treeckle/venues/views.py
@@ -41,16 +41,16 @@ from .logic import (
                 "description": "List of venue categories",
                 "example": [
                     "Conference Rooms",
-                    "Sports Facilities", 
+                    "Sports Facilities",
                     "Study Rooms",
                     "Event Halls",
-                    "Outdoor Spaces"
-                ]
+                    "Outdoor Spaces",
+                ],
             },
             401: {"description": "Authentication required"},
-            403: {"description": "Insufficient permissions"}
+            403: {"description": "Insufficient permissions"},
         },
-        tags=["Venues"]
+        tags=["Venues"],
     )
 )
 class VenueCategoriesView(APIView):
@@ -58,7 +58,7 @@ class VenueCategoriesView(APIView):
     def get(self, request, requester: User):
         """
         Get all venue categories in the user's organization.
-        
+
         Returns a list of category names that can be used for filtering venues
         or creating new venues. Only includes categories from the same organization.
         """
@@ -88,8 +88,8 @@ class VenueCategoriesView(APIView):
                         "venue": {
                             "id": 5,
                             "name": "Main Conference Room",
-                            "category": "Conference Rooms"
-                        }
+                            "category": "Conference Rooms",
+                        },
                     },
                     {
                         "id": 2,
@@ -98,15 +98,15 @@ class VenueCategoriesView(APIView):
                         "venue": {
                             "id": 8,
                             "name": "Basketball Court A",
-                            "category": "Sports Facilities"
-                        }
-                    }
-                ]
+                            "category": "Sports Facilities",
+                        },
+                    },
+                ],
             },
             401: {"description": "Authentication required"},
-            403: {"description": "Admin access required"}
+            403: {"description": "Admin access required"},
         },
-        tags=["Venue Notifications"]
+        tags=["Venue Notifications"],
     )
 )
 class BookingNotificationSubscriptionsView(APIView):
@@ -114,7 +114,7 @@ class BookingNotificationSubscriptionsView(APIView):
     def get(self, request, requester: User):
         """
         Get all booking notification subscriptions in the organization.
-        
+
         Returns subscriptions for all venues in the organization, showing
         who should be notified when bookings are made for each venue.
         """
@@ -140,7 +140,7 @@ class BookingNotificationSubscriptionsView(APIView):
                 description="Unique identifier of the venue to create subscription for",
                 required=True,
                 type=int,
-                location=OpenApiParameter.PATH
+                location=OpenApiParameter.PATH,
             )
         ],
         request=PostBookingNotificationSubscriptionSerializer,
@@ -154,9 +154,9 @@ class BookingNotificationSubscriptionsView(APIView):
                     "venue": {
                         "id": 12,
                         "name": "Auditorium",
-                        "category": "Event Halls"
-                    }
-                }
+                        "category": "Event Halls",
+                    },
+                },
             },
             400: {"description": "Invalid input data"},
             401: {"description": "Authentication required"},
@@ -166,11 +166,11 @@ class BookingNotificationSubscriptionsView(APIView):
                 "description": "Subscription already exists",
                 "example": {
                     "detail": "Booking notification subscription already exists.",
-                    "code": "booking_notification_subscription_exists"
-                }
-            }
+                    "code": "booking_notification_subscription_exists",
+                },
+            },
         },
-        tags=["Venue Notifications"]
+        tags=["Venue Notifications"],
     )
 )
 class SingleVenueBookingNotificationSubscriptionsView(APIView):
@@ -179,7 +179,7 @@ class SingleVenueBookingNotificationSubscriptionsView(APIView):
     def post(self, request, requester: User, venue: Venue):
         """
         Create a booking notification subscription for a venue.
-        
+
         Creates a new subscription that will send notifications to the specified
         email address when bookings are made for this venue. Each email can only
         have one subscription per venue.
@@ -216,7 +216,7 @@ class SingleVenueBookingNotificationSubscriptionsView(APIView):
                 description="Unique identifier of the subscription to delete",
                 required=True,
                 type=int,
-                location=OpenApiParameter.PATH
+                location=OpenApiParameter.PATH,
             )
         ],
         responses={
@@ -229,15 +229,15 @@ class SingleVenueBookingNotificationSubscriptionsView(APIView):
                     "venue": {
                         "id": 12,
                         "name": "Auditorium",
-                        "category": "Event Halls"
-                    }
-                }
+                        "category": "Event Halls",
+                    },
+                },
             },
             401: {"description": "Authentication required"},
             403: {"description": "Admin access required"},
-            404: {"description": "Subscription not found"}
+            404: {"description": "Subscription not found"},
         },
-        tags=["Venue Notifications"]
+        tags=["Venue Notifications"],
     )
 )
 class SingleBookingNotificationSubscriptionView(APIView):
@@ -251,7 +251,7 @@ class SingleBookingNotificationSubscriptionView(APIView):
     ):
         """
         Delete a booking notification subscription.
-        
+
         Permanently removes the subscription, stopping future notifications
         for bookings made to the associated venue.
         """
@@ -271,15 +271,15 @@ class SingleBookingNotificationSubscriptionView(APIView):
                 description="Filter venues by category name",
                 required=False,
                 type=str,
-                location=OpenApiParameter.QUERY
+                location=OpenApiParameter.QUERY,
             ),
             OpenApiParameter(
                 name="full_details",
                 description="Include full venue details including form fields and contact information",
                 required=False,
                 type=bool,
-                location=OpenApiParameter.QUERY
-            )
+                location=OpenApiParameter.QUERY,
+            ),
         ],
         responses={
             200: {
@@ -288,10 +288,7 @@ class SingleBookingNotificationSubscriptionView(APIView):
                     {
                         "id": 15,
                         "name": "Conference Room A",
-                        "category": {
-                            "id": 3,
-                            "name": "Conference Rooms"
-                        },
+                        "category": {"id": 3, "name": "Conference Rooms"},
                         "capacity": 25,
                         "ic_name": "John Manager",
                         "ic_email": "john.manager@university.edu",
@@ -300,26 +297,23 @@ class SingleBookingNotificationSubscriptionView(APIView):
                             {
                                 "field_name": "Purpose",
                                 "field_type": "text",
-                                "is_required": True
+                                "is_required": True,
                             },
                             {
                                 "field_name": "Equipment Needed",
                                 "field_type": "checkbox",
                                 "is_required": False,
-                                "options": ["Projector", "Microphone", "Whiteboard"]
-                            }
+                                "options": ["Projector", "Microphone", "Whiteboard"],
+                            },
                         ],
-                        "organization": {
-                            "id": 1,
-                            "name": "University College"
-                        }
+                        "organization": {"id": 1, "name": "University College"},
                     }
-                ]
+                ],
             },
             400: {"description": "Invalid query parameters"},
-            401: {"description": "Authentication required"}
+            401: {"description": "Authentication required"},
         },
-        tags=["Venues"]
+        tags=["Venues"],
     ),
     post=extend_schema(
         summary="Create New Venue",
@@ -331,10 +325,7 @@ class SingleBookingNotificationSubscriptionView(APIView):
                 "example": {
                     "id": 20,
                     "name": "Study Room B",
-                    "category": {
-                        "id": 5,
-                        "name": "Study Rooms"
-                    },
+                    "category": {"id": 5, "name": "Study Rooms"},
                     "capacity": 8,
                     "ic_name": "Library Staff",
                     "ic_email": "library@university.edu",
@@ -343,35 +334,29 @@ class SingleBookingNotificationSubscriptionView(APIView):
                         {
                             "field_name": "Number of Students",
                             "field_type": "number",
-                            "is_required": True
+                            "is_required": True,
                         }
                     ],
-                    "organization": {
-                        "id": 1,
-                        "name": "University College"
-                    }
-                }
+                    "organization": {"id": 1, "name": "University College"},
+                },
             },
             400: {"description": "Invalid input data"},
             401: {"description": "Authentication required"},
             403: {"description": "Admin access required"},
             409: {
                 "description": "Venue already exists",
-                "example": {
-                    "detail": "Venue already exists.",
-                    "code": "venue_exists"
-                }
-            }
+                "example": {"detail": "Venue already exists.", "code": "venue_exists"},
+            },
         },
-        tags=["Venues"]
-    )
+        tags=["Venues"],
+    ),
 )
 class VenuesView(APIView):
     @check_access(Role.RESIDENT, Role.ORGANIZER, Role.ADMIN)
     def get(self, request, requester: User):
         """
         Get venues in the organization.
-        
+
         Returns venues filtered by optional category parameter. The full_details
         parameter controls whether to include complete venue information including
         form fields and contact details, or just basic venue data.
@@ -399,7 +384,7 @@ class VenuesView(APIView):
     def post(self, request, requester: User):
         """
         Create a new venue.
-        
+
         Creates a venue with the provided details including custom form fields
         for booking requirements. Venue categories will be automatically created
         if they don't exist in the organization.
@@ -438,7 +423,7 @@ class VenuesView(APIView):
                 description="Unique identifier of the venue",
                 required=True,
                 type=int,
-                location=OpenApiParameter.PATH
+                location=OpenApiParameter.PATH,
             )
         ],
         responses={
@@ -447,10 +432,7 @@ class VenuesView(APIView):
                 "example": {
                     "id": 25,
                     "name": "Main Auditorium",
-                    "category": {
-                        "id": 8,
-                        "name": "Event Halls"
-                    },
+                    "category": {"id": 8, "name": "Event Halls"},
                     "capacity": 500,
                     "ic_name": "Events Manager",
                     "ic_email": "events.manager@university.edu",
@@ -460,30 +442,32 @@ class VenuesView(APIView):
                             "field_name": "Event Type",
                             "field_type": "select",
                             "is_required": True,
-                            "options": ["Conference", "Seminar", "Performance", "Graduation"]
+                            "options": [
+                                "Conference",
+                                "Seminar",
+                                "Performance",
+                                "Graduation",
+                            ],
                         },
                         {
                             "field_name": "Expected Attendance",
                             "field_type": "number",
-                            "is_required": True
+                            "is_required": True,
                         },
                         {
                             "field_name": "Technical Requirements",
                             "field_type": "textarea",
-                            "is_required": False
-                        }
+                            "is_required": False,
+                        },
                     ],
-                    "organization": {
-                        "id": 1,
-                        "name": "University College"
-                    }
-                }
+                    "organization": {"id": 1, "name": "University College"},
+                },
             },
             401: {"description": "Authentication required"},
             403: {"description": "Not authorized to view this venue"},
-            404: {"description": "Venue not found"}
+            404: {"description": "Venue not found"},
         },
-        tags=["Venues"]
+        tags=["Venues"],
     ),
     put=extend_schema(
         summary="Update Venue",
@@ -494,7 +478,7 @@ class VenuesView(APIView):
                 description="Unique identifier of the venue to update",
                 required=True,
                 type=int,
-                location=OpenApiParameter.PATH
+                location=OpenApiParameter.PATH,
             )
         ],
         request=VenueSerializer,
@@ -504,10 +488,7 @@ class VenuesView(APIView):
                 "example": {
                     "id": 25,
                     "name": "Updated Auditorium Name",
-                    "category": {
-                        "id": 8,
-                        "name": "Event Halls"
-                    },
+                    "category": {"id": 8, "name": "Event Halls"},
                     "capacity": 450,
                     "ic_name": "New Events Manager",
                     "ic_email": "new.events@university.edu",
@@ -517,14 +498,17 @@ class VenuesView(APIView):
                             "field_name": "Event Type",
                             "field_type": "select",
                             "is_required": True,
-                            "options": ["Conference", "Seminar", "Performance", "Graduation", "Workshop"]
+                            "options": [
+                                "Conference",
+                                "Seminar",
+                                "Performance",
+                                "Graduation",
+                                "Workshop",
+                            ],
                         }
                     ],
-                    "organization": {
-                        "id": 1,
-                        "name": "University College"
-                    }
-                }
+                    "organization": {"id": 1, "name": "University College"},
+                },
             },
             400: {"description": "Invalid input data"},
             401: {"description": "Authentication required"},
@@ -532,13 +516,10 @@ class VenuesView(APIView):
             404: {"description": "Venue not found"},
             409: {
                 "description": "Venue name already exists",
-                "example": {
-                    "detail": "Venue already exists.",
-                    "code": "venue_exists"
-                }
-            }
+                "example": {"detail": "Venue already exists.", "code": "venue_exists"},
+            },
         },
-        tags=["Venues"]
+        tags=["Venues"],
     ),
     delete=extend_schema(
         summary="Delete Venue",
@@ -549,7 +530,7 @@ class VenuesView(APIView):
                 description="Unique identifier of the venue to delete",
                 required=True,
                 type=int,
-                location=OpenApiParameter.PATH
+                location=OpenApiParameter.PATH,
             )
         ],
         responses={
@@ -558,27 +539,21 @@ class VenuesView(APIView):
                 "example": {
                     "id": 25,
                     "name": "Deleted Venue",
-                    "category": {
-                        "id": 8,
-                        "name": "Event Halls"
-                    },
+                    "category": {"id": 8, "name": "Event Halls"},
                     "capacity": 450,
                     "ic_name": "Events Manager",
                     "ic_email": "events@university.edu",
                     "ic_contact_number": "+65 9333 4444",
                     "form_field_data": [],
-                    "organization": {
-                        "id": 1,
-                        "name": "University College"
-                    }
-                }
+                    "organization": {"id": 1, "name": "University College"},
+                },
             },
             401: {"description": "Authentication required"},
             403: {"description": "Admin access required"},
-            404: {"description": "Venue not found"}
+            404: {"description": "Venue not found"},
         },
-        tags=["Venues"]
-    )
+        tags=["Venues"],
+    ),
 )
 class SingleVenueView(APIView):
     @check_access(Role.RESIDENT, Role.ORGANIZER, Role.ADMIN)
@@ -586,7 +561,7 @@ class SingleVenueView(APIView):
     def get(self, request, requester: User, venue: Venue):
         """
         Get detailed information about a specific venue.
-        
+
         Returns complete venue details including form fields, contact information,
         and organization details. Accessible to all authenticated users in the
         same organization.
@@ -600,7 +575,7 @@ class SingleVenueView(APIView):
     def put(self, request, requester: User, venue: Venue):
         """
         Update an existing venue.
-        
+
         Updates venue details including name, category, capacity, contact information,
         and custom form fields. Venue categories will be created if they don't exist.
         Only admins can update venues.
@@ -634,7 +609,7 @@ class SingleVenueView(APIView):
     def delete(self, request, requester: User, venue: Venue):
         """
         Delete an existing venue.
-        
+
         Permanently removes the venue and all associated data including bookings
         and notification subscriptions. Also cleans up any unused venue categories
         within the organization. Only admins can delete venues.

--- a/frontend/DEVELOPER_GUIDE.md
+++ b/frontend/DEVELOPER_GUIDE.md
@@ -1,0 +1,638 @@
+# Frontend Developer Guide
+
+## 📋 Table of Contents
+
+- [Technology Stack](#technology-stack)
+- [Project Structure](#project-structure)
+- [Development Setup](#development-setup)
+- [Development Workflow](#development-workflow)
+- [Component Development](#component-development)
+- [Code Style & Standards](#code-style--standards)
+- [Build & Deployment](#build--deployment)
+- [Performance Optimization](#performance-optimization)
+- [Troubleshooting](#troubleshooting)
+
+## 🛠️ Technology Stack
+
+### Core Framework
+
+- **React**: Modern React with hooks and concurrent features
+- **TypeScript**: Static typing for better development experience
+- **Vite**: Fast build tool and development server (migrated from CRA)
+
+### State Management
+
+- **Redux Toolkit**: Modern Redux with simplified setup
+- **React Redux**: React bindings for Redux
+
+### UI Framework & Styling
+
+- **Semantic UI React**: Component library for consistent UI
+- **Semantic UI CSS**: Base styling framework
+- **Sass**: CSS preprocessor for advanced styling
+- **CSS Modules**: Scoped styling support
+
+### Routing & Navigation
+
+- **React Router DOM**: Client-side routing
+- **React Router Last Location**: Location history tracking
+
+### Forms & Validation
+
+- **React Hook Form**: Performant forms with easy validation
+- **Hookform Resolvers**: Integration with validation schemas
+- **Yup**: Schema validation
+
+### HTTP & Data Fetching
+
+- **Axios**: HTTP client for API requests
+- **Axios Hooks**: React hooks for Axios integration
+
+### UI Components & Libraries
+
+- **React Big Calendar**: Calendar component for events
+- **React Beautiful DnD**: Drag and drop functionality
+- **React Base Table**: High-performance table component
+- **React Dropzone**: File upload with drag & drop
+- **React Easy Crop**: Image cropping functionality
+- **React Player**: Media player component
+- **React Toastify**: Toast notifications
+- **React Modal Hook**: Modal management
+
+### Utilities
+
+- **Lodash**: Utility functions
+- **Date-fns**: Date manipulation library
+- **Change Case**: String case conversion
+- **Fast Deep Equal**: Deep equality checks
+- **Query String**: URL query string parsing
+
+### Development Tools
+
+- **ESLint**: Code linting with multiple configurations
+- **Prettier**: Code formatting
+- **TypeScript ESLint**: TypeScript-specific linting rules
+- **Vitest**: Testing framework
+- **Source Map Explorer**: Bundle analysis
+
+## 📁 Project Structure
+
+```
+frontend/
+├── public/                    # Static assets
+│   ├── favicon.ico            # Site favicon
+│   ├── manifest.json          # PWA manifest
+│   ├── robots.txt             # Search engine crawling rules
+│   └── treeckle-logo.png      # App logo
+├── src/                       # Source code
+│   ├── app.tsx                # Main app component
+│   ├── index.tsx              # Application entry point
+│   ├── configs.ts             # Environment configuration
+│   ├── react-app-env.d.ts     # React type definitions
+│   ├── _base.scss             # Global base styles
+│   ├── index.scss             # Global styles
+│   ├── app.module.scss        # App component styles
+│   ├── assets/                # Static assets (images, icons)
+│   │   ├── images/            # Image files
+│   │   └── icons/             # Icon files
+│   ├── components/            # Reusable UI components
+│   │   ├── common/            # Generic components
+│   │   │   ├── Button/        # Custom button components
+│   │   │   ├── Modal/         # Modal components
+│   │   │   ├── Form/          # Form components
+│   │   │   ├── Table/         # Table components
+│   │   │   └── Layout/        # Layout components
+│   │   ├── auth/              # Authentication components
+│   │   ├── booking/           # Booking-related components
+│   │   ├── event/             # Event-related components
+│   │   ├── venue/             # Venue-related components
+│   │   └── user/              # User-related components
+│   ├── pages/                 # Page components (route components)
+│   │   ├── AuthPage/          # Authentication page
+│   │   ├── DashboardPage/     # Main dashboard
+│   │   ├── BookingPage/       # Booking management
+│   │   ├── EventPage/         # Event management
+│   │   ├── VenuePage/         # Venue management
+│   │   ├── ProfilePage/       # User profile
+│   │   └── AdminPage/         # Admin panel
+│   ├── redux/                 # Redux store setup
+│   │   ├── store.ts           # Store configuration
+│   │   ├── slices/            # Redux Toolkit slices
+│   │   │   ├── authSlice.ts   # Authentication state
+│   │   │   ├── bookingSlice.ts # Booking state
+│   │   │   ├── eventSlice.ts  # Event state
+│   │   │   ├── venueSlice.ts  # Venue state
+│   │   │   └── userSlice.ts   # User state
+│   │   └── middleware/        # Custom middleware
+│   ├── routes/                # Routing configuration
+│   │   ├── AppRouter.tsx      # Main router component
+│   │   ├── ProtectedRoute.tsx # Route protection
+│   │   └── routeConstants.ts  # Route path constants
+│   ├── contexts/              # React contexts
+│   │   ├── AuthContext.tsx    # Authentication context
+│   │   └── ThemeContext.tsx   # Theme context
+│   ├── custom-hooks/          # Custom React hooks
+│   │   ├── useApi.ts          # API request hook
+│   │   ├── useAuth.ts         # Authentication hook
+│   │   ├── useLocalStorage.ts # Local storage hook
+│   │   └── useDebounce.ts     # Debouncing hook
+│   ├── managers/              # API managers
+│   │   ├── AuthManager.ts     # Authentication API calls
+│   │   ├── BookingManager.ts  # Booking API calls
+│   │   ├── EventManager.ts    # Event API calls
+│   │   ├── VenueManager.ts    # Venue API calls
+│   │   └── UserManager.ts     # User API calls
+│   ├── types/                 # TypeScript type definitions
+│   │   ├── auth.ts            # Authentication types
+│   │   ├── booking.ts         # Booking types
+│   │   ├── event.ts           # Event types
+│   │   ├── venue.ts           # Venue types
+│   │   ├── user.ts            # User types
+│   │   └── api.ts             # API response types
+│   ├── constants/             # Application constants
+│   │   ├── apiConstants.ts    # API endpoints
+│   │   ├── appConstants.ts    # General app constants
+│   │   ├── routeConstants.ts  # Route constants
+│   │   └── uiConstants.ts     # UI-related constants
+│   └── utils/                 # Utility functions
+│       ├── dateUtils.ts       # Date manipulation utilities
+│       ├── formatUtils.ts     # Formatting utilities
+│       ├── validationUtils.ts # Validation utilities
+│       ├── storageUtils.ts    # Local storage utilities
+│       └── apiUtils.ts        # API utilities
+├── component-creator.js      # Component scaffolding script
+├── package.json              # Dependencies and scripts
+├── tsconfig.json             # TypeScript configuration
+├── vite.config.ts            # Vite configuration
+├── eslint.config.mjs         # ESLint configuration
+├── build-prod.sh             # Production build script
+├── build.sh                  # Development build script
+├── Dockerfile                # Docker configuration
+└── nginx/                    # Nginx configuration for production
+    └── nginx.conf
+```
+
+## 🚀 Development Setup
+
+### 1. Prerequisites
+
+Ensure you have the following installed:
+
+- [Node.js](https://nodejs.org/) 16+ (LTS recommended)
+- [Yarn](https://yarnpkg.com/) (required, npm is not supported)
+- [Git](https://git-scm.com/)
+
+### 2. Clone and Navigate
+
+```bash
+git clone https://github.com/CAPTxTreeckle/Treeckle-3.0.git
+cd Treeckle-3.0/frontend
+```
+
+### 3. Install Dependencies
+
+```bash
+# Install all dependencies (use yarn, not npm)
+yarn install
+```
+
+### 4. Start Development Server
+
+```bash
+# Start development server
+yarn dev
+
+# Start with HTTPS (for OAuth testing)
+yarn dev:https
+```
+
+The application will be available at `http://localhost:3000`
+
+## 🔄 Development Workflow
+
+### Available Scripts
+
+```bash
+# Development
+yarn dev                   # Start development server
+yarn dev:https             # Start with HTTPS
+
+# Building
+yarn build                 # Build for production
+yarn build:analyze         # Build with bundle analysis
+
+# Code Quality
+yarn format                # Format code with Prettier
+yarn lint                  # Run ESLint
+yarn lint --fix            # Auto-fix ESLint issues
+
+# Testing
+yarn test                  # Run tests
+yarn test:ui               # Run tests with UI
+
+# Utilities
+yarn create-component      # Create new component scaffolding
+yarn serve                 # Preview production build
+```
+
+### Pre-commit Checks
+
+Before building for production, the following checks run automatically:
+
+1. **Prettier formatting**: `yarn format`
+2. **ESLint linting**: `yarn lint --fix`
+3. **TypeScript compilation**: Type checking
+
+### Component Creation
+
+Use the scaffolding script to create new components:
+
+```bash
+yarn create-component
+```
+
+This will prompt you for:
+
+- Component name
+- Component type (functional, class, etc.)
+- Whether to include styles
+- Whether to include tests
+
+## 🧩 Component Development
+
+### Component Architecture
+
+Components follow a consistent structure:
+
+```
+ComponentName/
+├── index.tsx              # Main component file
+├── ComponentName.module.scss  # Component styles
+├── types.ts               # Component-specific types
+└── hooks.ts               # Component-specific hooks (if needed)
+```
+
+### Best Practices
+
+1. **Use TypeScript interfaces** for all props
+2. **Implement proper error boundaries** for complex components
+3. **Use React.memo** for performance optimization when needed
+4. **Follow the single responsibility principle**
+5. **Use composition over inheritance**
+6. **Implement proper loading and error states**
+
+## 📏 Code Style & Standards
+
+### Coding Standards
+
+#### 1. File and Folder Naming
+
+- Use **PascalCase** for component files and folders
+- Use **camelCase** for utility files and hooks
+- Use **kebab-case** for CSS/SCSS files
+
+#### 2. Component Structure
+
+```tsx
+// ✅ Good component structure
+import React, { useState, useEffect } from "react";
+import { useSelector, useDispatch } from "react-redux";
+
+// Type imports
+import { ComponentProps } from "./types";
+
+// Styles
+import styles from "./Component.module.scss";
+
+// Constants
+const COMPONENT_CONSTANTS = {
+  DEFAULT_VALUE: "default",
+} as const;
+
+const Component: React.FC<ComponentProps> = ({ prop1, prop2, ...rest }) => {
+  // State
+  const [localState, setLocalState] = useState("");
+
+  // Redux
+  const dispatch = useDispatch();
+  const globalState = useSelector((state) => state.feature);
+
+  // Effects
+  useEffect(() => {
+    // Effect logic
+  }, []);
+
+  // Handlers
+  const handleAction = () => {
+    // Handler logic
+  };
+
+  // Render helpers
+  const renderContent = () => {
+    // Render logic
+  };
+
+  return <div className={styles.component}>{renderContent()}</div>;
+};
+
+export default Component;
+```
+
+#### 3. Type Definitions
+
+```tsx
+// ✅ Good type definitions
+export interface User {
+  id: number;
+  name: string;
+  email: string;
+  role: UserRole;
+  organization: Organization;
+  profileImage?: ProfileImage | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export enum UserRole {
+  ADMIN = "ADMIN",
+  ORGANIZER = "ORGANIZER",
+  RESIDENT = "RESIDENT",
+}
+
+export interface ApiResponse<T> {
+  success: boolean;
+  data: T;
+  message?: string;
+  errors?: string[];
+}
+```
+
+#### 4. Constants Organization
+
+```tsx
+// constants/appConstants.ts
+export const APP_CONFIG = {
+  NAME: "Treeckle",
+  VERSION: "3.0.0",
+  API_TIMEOUT: 10000,
+} as const;
+
+export const USER_ROLES = {
+  ADMIN: "ADMIN",
+  ORGANIZER: "ORGANIZER",
+  RESIDENT: "RESIDENT",
+} as const;
+
+export const BOOKING_STATUSES = {
+  PENDING: "PENDING",
+  APPROVED: "APPROVED",
+  REJECTED: "REJECTED",
+  CANCELLED: "CANCELLED",
+} as const;
+```
+
+## 🚀 Build & Deployment
+
+### Performance Optimization
+
+#### Code Splitting
+
+```tsx
+// Lazy loading components
+import { lazy, Suspense } from "react";
+
+const BookingPage = lazy(() => import("../pages/BookingPage"));
+const EventPage = lazy(() => import("../pages/EventPage"));
+
+const App = () => (
+  <Suspense fallback={<div>Loading...</div>}>
+    <Switch>
+      <Route path="/bookings" component={BookingPage} />
+      <Route path="/events" component={EventPage} />
+    </Switch>
+  </Suspense>
+);
+```
+
+## ⚡ Performance Optimization
+
+### React Performance
+
+#### 1. Memoization
+
+```tsx
+// Memoize expensive calculations
+const ExpensiveComponent = ({ data }) => {
+  const processedData = useMemo(() => {
+    return data.map((item) => expensiveCalculation(item));
+  }, [data]);
+
+  return <div>{processedData}</div>;
+};
+
+// Memoize callbacks
+const OptimizedComponent = ({ onSave }) => {
+  const handleSave = useCallback(
+    (data) => {
+      onSave(data);
+    },
+    [onSave],
+  );
+
+  return <ChildComponent onSave={handleSave} />;
+};
+
+// Memoize components
+export default React.memo(Component);
+```
+
+#### 2. Virtual Scrolling
+
+```tsx
+// For large lists
+import { FixedSizeList as List } from "react-window";
+
+const VirtualizedList = ({ items }) => (
+  <List height={600} itemCount={items.length} itemSize={50} itemData={items}>
+    {({ index, style, data }) => (
+      <div style={style}>
+        <ItemComponent item={data[index]} />
+      </div>
+    )}
+  </List>
+);
+```
+
+#### 3. Image Optimization
+
+```tsx
+// Lazy loading images
+import { useState } from "react";
+
+const LazyImage = ({ src, alt, ...props }) => {
+  const [loaded, setLoaded] = useState(false);
+
+  return (
+    <div className="image-container">
+      {!loaded && <div className="image-placeholder" />}
+      <img
+        src={src}
+        alt={alt}
+        onLoad={() => setLoaded(true)}
+        style={{ display: loaded ? "block" : "none" }}
+        {...props}
+      />
+    </div>
+  );
+};
+```
+
+### Bundle Optimization
+
+#### 1. Tree Shaking
+
+```tsx
+// ✅ Import only what you need
+import { debounce } from "lodash/debounce";
+import { format } from "date-fns";
+
+// ❌ Avoid importing entire libraries
+import _ from "lodash";
+import * as dateFns from "date-fns";
+```
+
+#### 2. Dynamic Imports
+
+```tsx
+// Dynamic imports for conditional functionality
+const loadAdvancedFeatures = async () => {
+  if (user.role === "ADMIN") {
+    const { AdminPanel } = await import("./AdminPanel");
+    return AdminPanel;
+  }
+  return null;
+};
+```
+
+## 🔧 Troubleshooting
+
+### Common Issues
+
+#### 1. Build Errors
+
+**TypeScript compilation errors:**
+
+```bash
+# Clear TypeScript cache
+rm -rf node_modules/.cache
+yarn install
+
+# Check TypeScript configuration
+yarn tsc --noEmit
+```
+
+**Module resolution errors:**
+
+```bash
+# Clear all caches
+rm -rf node_modules
+rm yarn.lock
+yarn install
+```
+
+#### 2. Runtime Errors
+
+**Redux state issues:**
+
+```tsx
+// Check Redux DevTools
+// Ensure proper action dispatching
+const dispatch = useDispatch<AppDispatch>();
+
+// Verify state shape
+const state = useSelector((state: RootState) => state.feature);
+```
+
+**Routing issues:**
+
+```tsx
+// Check route configuration
+// Verify protected route logic
+// Ensure proper redirect logic
+```
+
+#### 3. Performance Issues
+
+**Large bundle size:**
+
+```bash
+# Analyze bundle
+yarn build:analyze
+
+# Check for duplicate dependencies
+npx duplicate-package-checker-webpack-plugin
+```
+
+**Slow rendering:**
+
+```tsx
+// Use React DevTools Profiler
+// Add performance monitoring
+const Component = () => {
+  console.time("Component render");
+
+  useEffect(() => {
+    console.timeEnd("Component render");
+  });
+
+  return <div>Content</div>;
+};
+```
+
+#### 4. Development Server Issues
+
+**Port conflicts:**
+
+```bash
+# Kill processes on port 3000
+npx kill-port 3000
+
+# Use different port
+VITE_PORT=3001 yarn dev
+```
+
+**Hot reload not working:**
+
+```bash
+# Check file system limits
+echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf
+
+# Restart development server
+yarn dev
+```
+
+### Debug Tools
+
+#### 1. Browser DevTools
+
+- **React DevTools**: Component inspection and profiling
+- **Redux DevTools**: State debugging and time-travel
+- **Network Tab**: API request monitoring
+- **Performance Tab**: Runtime performance analysis
+
+#### 2. VS Code Extensions
+
+- **ES7+ React/Redux/React-Native snippets**
+- **Prettier - Code formatter**
+- **ESLint**
+
+### Getting Help
+
+1. Check the [React documentation](https://reactjs.org/docs)
+2. Check the [Redux Toolkit documentation](https://redux-toolkit.js.org/)
+3. Check the [Semantic UI React documentation](https://react.semantic-ui.com/)
+4. Review existing patterns in the codebase
+
+---
+
+**Happy coding! 🎉**


### PR DESCRIPTION
Closes #44 

- Setup Swagger with Django REST framework
- Add documentation for API endpoints
- Update README
- Add Developer Guide for frontend and backend

The API documentation can be found at the following endpoints:
- **Swagger UI**: http://localhost:8000/api/swagger/ - Interactive API documentation
- **ReDoc**: http://localhost:8000/api/redoc/ - Alternative documentation format
- **OpenAPI Schema**: http://localhost:8000/api/schema/ - Raw OpenAPI schema JSON