### PR TITLE
Fix 404 nginx error

### DIFF
--- a/app-reverse-proxy/nginx-base.conf
+++ b/app-reverse-proxy/nginx-base.conf
@@ -12,9 +12,21 @@ proxy_set_header Host $http_host_final;
 proxy_cache_bypass $http_upgrade;
 proxy_redirect off;
 
-## serve frontend contents
+# intercept proxied 4xx/5xx so we can serve SPA index.html for client-side routes
+proxy_intercept_errors on;
+
+## serve frontend contents (SPA). If the frontend returns 404 for a client-side
+## route, internally fall back to /index.html so the React router can handle it.
 location / {
 	proxy_pass http://$frontend;
+	# when the proxied frontend responds 404, rewrite internally to /index.html
+	error_page 404 = /index.html;
+}
+
+# Fetch the SPA index directly from the frontend upstream. This is used by the
+# internal rewrite above to return the application shell for unknown routes.
+location = /index.html {
+	proxy_pass http://$frontend/index.html;
 }
 
 ## access backend api


### PR DESCRIPTION
Fix #142 

<img width="504" height="168" alt="image" src="https://github.com/user-attachments/assets/d4f8b196-2b25-4ada-b1fe-b16ab7453ec5" />

How to reproduce error: When visiting treeckle.com, it will work and redirect to treeckle.com/dashboard. However, when refreshing it, it will cause error 404 Not Found: The requested URL was not found . When visitting treeckle.com/dashboard, it will have 404 not found error also. treeckle.com/something all won't work and will cause 404 not found

What I changed to fix: The current config proxied all requests location / to the frontend upstream. If the upstream served statis files and returned 404 for a client-side route, the browser got a 404. By enabling proxy_intercept_errors and adding error_page 404 = /index.html; in location /, nginx will intercept a 404 coming from the frontend and internally serve /index.html (which is proxied from the frontend as well). That returns the SPA shell and lets the React router handle the route on the client side.

Concern: Now refreshing website or visit treeckle.com/{something} will only directly to treeckle.com/ which is treeckle.com/dashboard.